### PR TITLE
chore: commit previously-uncommitted docs files (T-400)

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -1,0 +1,101 @@
+---
+tracker:
+  kind: linear
+  api_key: $LINEAR_API_KEY
+  project_slug: "b589976f0398"
+  active_states:
+    - Todo
+    - In Progress
+    - Merging
+    - Rework
+  terminal_states:
+    - Closed
+    - Cancelled
+    - Canceled
+    - Duplicate
+    - Done
+polling:
+  interval_ms: 5000
+workspace:
+  root: ~/cadeia-dominial-workspaces
+server:
+  port: 4000
+  host: "0.0.0.0"
+hooks:
+  after_create: |
+    git clone --depth 1 https://github.com/transistir/CadeiaDominial.git .
+    # Use o caller-supplied git identity; cai para defaults seguros se as envs não existirem.
+    git config user.email "${GIT_AUTHOR_EMAIL:-symphony-bot@cadeia-dominial.local}"
+    git config user.name  "${GIT_AUTHOR_NAME:-Symphony Kanban Bot}"
+    python -m venv .venv
+    . .venv/bin/activate
+    python -m pip install --upgrade pip
+    pip install -r requirements.txt
+agent:
+  # Debian 13 server has 2 vCPU and 3.7 GiB RAM; keep concurrency conservative.
+  max_concurrent_agents: 2
+  max_turns: 20
+codex:
+  command: codex --config shell_environment_policy.inherit=all --config plugins.github@openai-curated.enabled=false app-server
+  approval_policy: never
+  thread_sandbox: workspace-write
+  turn_sandbox_policy:
+    type: workspaceWrite
+---
+
+Você está trabalhando na issue Linear `{{ issue.identifier }}` do projeto **Cadeia Dominial**.
+
+{% if attempt %}
+Contexto de continuação:
+- Esta é a tentativa de retry #{{ attempt }} porque o ticket ainda está em estado ativo.
+- Continue a partir do estado atual do workspace em vez de reiniciar do zero.
+{% endif %}
+
+**Contexto da issue:**
+- Identificador: {{ issue.identifier }}
+- Título: {{ issue.title }}
+- Status atual: {{ issue.state }}
+- Labels: {{ issue.labels }}
+- URL: {{ issue.url }}
+
+**Descrição:**
+{% if issue.description %}
+{{ issue.description }}
+{% else %}
+Nenhuma descrição fornecida.
+{% endif %}
+
+## Sobre o projeto
+
+O **Cadeia Dominial** é um sistema Django 5.2 para gerenciamento de cadeia dominial de imóveis.
+Stack: Django + PostgreSQL + Gunicorn + Docker.
+
+## Instruções
+
+1. Esta é uma sessão de orquestração autônoma. Não peça intervenção humana.
+2. Trabalhe apenas no repositório fornecido no workspace.
+3. Use o workpad (`## Codex Workpad`) como fonte de verdade para progresso.
+4. Mantenha o status do ticket atualizado no Linear.
+5. Antes de mover para `Human Review`, garanta que:
+   - Todos os testes passam
+   - O código segue os padrões do projeto (ver COMMIT_CONVENTION.md)
+   - PR criado com label `symphony`
+   - Link do PR e resumo de validação registrados no workpad
+
+## Fluxo de status
+
+- `Todo` → mover para `In Progress` e começar trabalho
+- `In Progress` → implementar, testar, criar PR
+- `Human Review` → aguardar revisão humana
+- `Merging` → executar merge via `land` skill
+- `Rework` → recomeçar com base no feedback
+- `Done` → estado terminal
+
+## Validação
+
+Antes de cada push, execute:
+```bash
+. .venv/bin/activate 2>/dev/null || true
+python manage.py check
+python manage.py test
+```

--- a/docs/ERD_CADEIA_DOMINIAL.md
+++ b/docs/ERD_CADEIA_DOMINIAL.md
@@ -1,0 +1,269 @@
+# Diagrama ERD — Cadeia Dominial
+
+## Schema do Banco de Dados
+
+```mermaid
+erDiagram
+    TIs {
+        int id PK
+        string nome
+        string codigo UK
+        string etnia
+        string estado
+        decimal area
+        date data_cadastro
+    }
+
+    TerraIndigenaReferencia {
+        int id PK
+        string codigo UK
+        string nome
+        string etnia
+        string estado
+        string municipio
+        float area_ha
+        string fase
+        string modalidade
+        date data_regularizada
+        datetime created_at
+        datetime updated_at
+    }
+
+    Imovel {
+        int id PK
+        string nome
+        string matricula
+        string tipo_documento_principal
+        text observacoes
+        date data_cadastro
+        boolean arquivado
+    }
+
+    Cartorios {
+        int id PK
+        string nome
+        string cns UK
+        string endereco
+        string telefone
+        string email
+        string estado
+        string cidade
+        string tipo
+    }
+
+    ImportacaoCartorios {
+        int id PK
+        string estado
+        datetime data_inicio
+        datetime data_fim
+        int total_cartorios
+        string status
+        text erro
+    }
+
+    Pessoas {
+        int id PK
+        string nome
+        string cpf UK
+        string rg
+        date data_nascimento
+        string email
+        string telefone
+    }
+
+    DocumentoTipo {
+        int id PK
+        string tipo
+    }
+
+    Documento {
+        int id PK
+        string numero
+        date data
+        string livro
+        string folha
+        text origem
+        text observacoes
+        date data_cadastro
+        int nivel_manual
+        string classificacao_fim_cadeia
+        string sigla_patrimonio_publico
+    }
+
+    LancamentoTipo {
+        int id PK
+        string tipo
+        boolean requer_transmissao
+        boolean requer_detalhes
+        boolean requer_titulo
+        boolean requer_cartorio_origem
+        boolean requer_livro_origem
+        boolean requer_folha_origem
+        boolean requer_data_origem
+        boolean requer_forma
+        boolean requer_descricao
+        boolean requer_observacao
+    }
+
+    Lancamento {
+        int id PK
+        string numero_lancamento
+        date data
+        decimal valor_transacao
+        decimal area
+        string origem
+        text detalhes
+        text observacoes
+        date data_cadastro
+        string forma
+        text descricao
+        string titulo
+        string livro_transacao
+        string folha_transacao
+        date data_transacao
+        string livro_origem
+        string folha_origem
+        date data_origem
+        boolean eh_inicio_matricula
+    }
+
+    LancamentoPessoa {
+        int id PK
+        string tipo
+        string nome_digitado
+    }
+
+    OrigemFimCadeia {
+        int id PK
+        int indice_origem
+        boolean fim_cadeia
+        string tipo_fim_cadeia
+        text especificacao_fim_cadeia
+        string classificacao_fim_cadeia
+    }
+
+    FimCadeia {
+        int id PK
+        string nome UK
+        string tipo
+        string classificacao
+        string sigla
+        text descricao
+        boolean ativo
+        datetime data_criacao
+        datetime data_atualizacao
+    }
+
+    AlteracoesTipo {
+        int id PK
+        string tipo
+    }
+
+    RegistroTipo {
+        int id PK
+        string tipo
+    }
+
+    AverbacoesTipo {
+        int id PK
+        string tipo
+    }
+
+    Alteracoes {
+        int id PK
+        string livro
+        string folha
+        date data_alteracao
+        string titulo
+        string livro_origem
+        string folha_origem
+        date data_origem
+        decimal valor_transacao
+        decimal area
+        text observacoes
+        date data_cadastro
+    }
+
+    TIs_Imovel {
+        int id PK
+    }
+
+    DocumentoImportado {
+        int id PK
+        datetime data_importacao
+    }
+
+    %% ==================== RELACIONAMENTOS ====================
+
+    %% Terra Indigena
+    TIs ||--o| TerraIndigenaReferencia : "terra_referencia"
+    TIs ||--o{ TIs_Imovel : "tem"
+    Imovel ||--o{ TIs_Imovel : "associado_a"
+
+    %% Imovel
+    Imovel ||--o{ Documento : "possui"
+    Imovel ||--o{ Alteracoes : "historico"
+    Imovel }o--|| Pessoas : "proprietario"
+    Imovel }o--|| TIs : "terra_indigena"
+
+    %% Cartorio
+    Cartorios ||--o{ Imovel : "registra"
+    Cartorios ||--o{ Documento : "emissor"
+    Cartorios ||--o{ Lancamento : "cartorio_origem"
+    Cartorios ||--o{ Lancamento : "cartorio_transacao"
+    Cartorios ||--o{ Lancamento : "cartorio_transmissao"
+    Cartorios ||--o{ Alteracoes : "cartorio_responsavel"
+    Documento }o--|| Cartorios : "cri_atual"
+    Documento }o--|| Cartorios : "cri_origem"
+
+    %% Pessoa
+    Pessoas ||--o{ Lancamento : "transmitente"
+    Pessoas ||--o{ Lancamento : "adquirente"
+    Pessoas ||--o{ LancamentoPessoa : "envolvida"
+    Pessoas ||--o{ Alteracoes : "transmitente_alt"
+    Pessoas ||--o{ Alteracoes : "adquirente_alt"
+
+    %% Documento
+    Documento }o--|| DocumentoTipo : "classificado_como"
+    Documento ||--o{ Lancamento : "lancamentos"
+    Documento ||--o{ Lancamento : "documento_origem"
+    Documento ||--o{ DocumentoImportado : "importacoes"
+
+    %% Lancamento
+    Lancamento }o--|| LancamentoTipo : "tipo_de_lancamento"
+    Lancamento ||--o{ LancamentoPessoa : "pessoas"
+    Lancamento ||--o{ OrigemFimCadeia : "origens_fim_cadeia"
+
+    %% Alteracao
+    Alteracoes }o--|| AlteracoesTipo : "tipo_alteracao"
+    Alteracoes }o--|| RegistroTipo : "tipo_registro"
+    Alteracoes }o--|| AverbacoesTipo : "tipo_averbacao"
+
+    %% DocumentoImportado
+    %% (relação Documento -> DocumentoImportado já declarada em Documento acima; manter só a referência ao imóvel de origem)
+    DocumentoImportado }o--|| Imovel : "imovel_origem"
+```
+
+## Legenda das Entidades
+
+| Entidade | Descrição |
+|----------|-----------|
+| **Imovel** | Entidade central — imóveis registrados com matrícula única por cartório |
+| **Documento** | Documentos (matrículas/transcrições) associados a um imóvel |
+| **Lancamento** | Lançamentos da cadeia dominial (registros, averbações, início de matrícula) |
+| **LancamentoPessoa** | Pessoas (transmitentes/adquirentes) associadas a lançamentos |
+| **Pessoas** | Pessoas físicas/jurídicas envolvidas |
+| **Cartorios** | Cartórios de Registro de Imóveis |
+| **Alteracoes** | Alterações sobre imóveis (registros/averbações) |
+| **TIs** | Terras Indígenas sobrepostas |
+| **FimCadeia** | Tipos configuráveis de fim de cadeia dominial |
+| **DocumentoImportado** | Rastreamento de documentos importados entre cadeias |
+
+## Relacionamentos Principais
+
+- **Imovel ↔ Documento**: 1:N — um imóvel pode ter múltiplos documentos
+- **Documento ↔ Lancamento**: 1:N — um documento pode ter vários lançamentos
+- **Lancamento ↔ LancamentoPessoa**: 1:N — um lançamento pode ter múltiplas pessoas
+- **Imovel ↔ Alteracoes**: 1:N — um imóvel tem um histórico de alterações
+- **Imovel ↔ TIs**: 1:N via `Imovel.terra_indigena_id` (FK direta para uma TI) + N:N via `TIs_Imovel` (junction) — a FK cobre a relação principal; o junction modela sobreposições históricas/opcional
+- **Documento → Lancamento (documento_origem)**: cada Documento é o documento de origem de N Lancamentos (chain link) — FK `Lancamento.documento_origem_id` aponta para `Documento`


### PR DESCRIPTION
## Summary
Commits two files that were untracked in the v2 worktree.

## Files
- `docs/ERD_CADEIA_DOMINIAL.md` — Mermaid ERD of the legacy Django model (source: `docs/legacy-django/03-database-models.md`); generated with `mmdr`.
- `WORKFLOW.md` — Symphony Kanban tracker config (Linear project + states, polling, workspace root).

## Notes
- `docs/ERD_CADEIA_DOMINIAL.png` (rendered image) is intentionally **not** included in this commit — the `.md` is the source and can be re-rendered.
- `WORKFLOW.md` is tool configuration rather than project documentation, but committed per current instruction. Open to moving it to a separate `tools/` or `symphony/` location in a follow-up.

## Tasks
- T-400

## Base
- `v2` (not `main`).