### PR TITLE
docs(agents): document development workflow + worktree lifecycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # Repository Guidelines
 
+**For AI coding agents.** Humans: see `README.md` for the project overview.
+
 ## Project Layout
 
 This repository is one part of a larger project directory. The convention is:
@@ -8,14 +10,14 @@ This repository is one part of a larger project directory. The convention is:
 <project-root>/
 ├── CadeiaDominial/      # Main checkout, on integration branch `v2`
 ├── worktrees/           # Per-task worktrees (one branch per task)
-└── workspaces/          # Kanban per-issue workspaces (orchestrator-managed)
+└── workspaces/          # Per-issue workspaces (managed by the Kanban orchestrator)
 ```
 
 - `docs/` holds primary deliverables: migration guides, architecture decisions, legacy references. Start here for context.
 - `docs/legacy-django/` documents the historical Django implementation kept in `old/`.
 - `old/` contains legacy Django artifacts; not the active codebase.
 - `scripts/` holds the PostgreSQL → SQLite migration toolkit.
-- `WORKFLOW.md` is a tool config consumed by an orchestrator — treat as data, not as documentation.
+- `WORKFLOW.md` is consumed by the Kanban orchestrator as tool config — treat as data, not as documentation.
 
 ## Development Workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,25 +23,26 @@ This repository is one part of a larger project directory. The convention is:
 
 ### Lifecycle
 
-1. From the main checkout on `v2`, confirm with `git status` and `git branch --show-current`.
+1. **Start from the main checkout on `v2`.** Run `git status` and `git branch --show-current` — expect `v2`. If you are already in a worktree, run `git worktree list` and `cd` to the worktree whose branch is `v2` (the main checkout).
 2. Create a worktree for the task:
    ```bash
    git fetch origin
+   mkdir -p ../worktrees
    git worktree add -b <type>/<short-task> ../worktrees/<short> origin/v2
    cd ../worktrees/<short>
    ```
 3. Work in the worktree — all commits, pushes, and PR work happen here.
 4. Push and open a PR against `v2`.
-5. After CI passes and the PR is merged, clean up:
+5. After CI passes and the PR is merged, return to the main checkout, clean up, and pull the new `v2` tip:
    ```bash
+   cd ../../CadeiaDominial
+   git status
+   git branch --show-current  # should be v2
    git worktree remove --force ../worktrees/<short>
    git branch -D <type>/<short-task>
    git push origin --delete <type>/<short-task> 2>/dev/null  # OK if already gone
    git remote prune origin
-   ```
-6. From the main checkout, pull the new `v2` tip:
-   ```bash
-   git -C ../CadeiaDominial pull origin v2
+   git pull origin v2
    ```
 
 ### Conventions
@@ -69,12 +70,13 @@ This branch tracks the roadmap and pending decisions. It is also kept as a long-
 This repository snapshot is documentation-focused; the TypeScript monorepo described in `README.md` and `docs/MIGRATION_GUIDE.md` is not present here. When working against the full monorepo:
 
 ```bash
-pnpm dev                       # Start API + web together
-pnpm -C packages/web dev       # Frontend dev server
-pnpm -C packages/api dev       # API dev server
+pnpm install                  # Install workspace dependencies (one-time)
+pnpm dev                      # Start API + web together
+pnpm -C packages/web dev      # Frontend dev server
+pnpm -C packages/api dev      # API dev server
 pnpm -C packages/api db:generate
 pnpm -C packages/api db:migrate:local
-pnpm test                      # Vitest + Playwright
+pnpm test                     # Vitest + Playwright
 pnpm format && pnpm lint
 ```
 
@@ -88,7 +90,7 @@ If you only touch `docs/`, no build step is required.
 
 ## Testing Guidelines
 
-- The planned stack uses Vitest and Playwright with an 80% coverage target.
+- This documentation snapshot has no configured automated test runner. When working against the full monorepo, use Vitest and Playwright with an 80% coverage target.
 - For frontend visual/interaction checks, use Agent Browser (`agent-browser` or `npx @vercel-labs/agent-browser`) and document results in the relevant PRD or progress notes.
 
 ## Commit & Pull Request Guidelines

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,89 +1,104 @@
 # Repository Guidelines
 
-## Project Structure & Module Organization
+## Project Layout
 
-- `docs/` holds the primary deliverables: migration guides, architecture decisions, and legacy Django references. Start here for context.
-- `docs/legacy-django/` documents the historical Django implementation that was moved to `old/`.
-- `old/` contains legacy Django artifacts (and data files) kept for reference; it is not the active codebase.
-- `scripts/` holds the PostgreSQL → SQLite migration toolkit (see `scripts/pg_sqlite_migration/`).
-- `README.md` describes the target TypeScript monorepo and Cloudflare deployment plan.
+This repository is one part of a larger project directory. The convention is:
+
+```
+<project-root>/
+├── CadeiaDominial/      # Main checkout, on integration branch `v2`
+├── worktrees/           # Per-task worktrees (one branch per task)
+└── workspaces/          # Kanban per-issue workspaces (orchestrator-managed)
+```
+
+- `docs/` holds primary deliverables: migration guides, architecture decisions, legacy references. Start here for context.
+- `docs/legacy-django/` documents the historical Django implementation kept in `old/`.
+- `old/` contains legacy Django artifacts; not the active codebase.
+- `scripts/` holds the PostgreSQL → SQLite migration toolkit.
+- `WORKFLOW.md` is a tool config consumed by an orchestrator — treat as data, not as documentation.
+
+## Development Workflow
+
+**One main checkout + one worktree per task.** The integration branch is **`v2`** (never `main` — `main` is the original GitHub default and is not the working branch). All new work happens on a worktree branched from `origin/v2`, opens a PR against `v2`, and is cleaned up after merge.
+
+### Lifecycle
+
+1. From the main checkout on `v2`, confirm with `git status` and `git branch --show-current`.
+2. Create a worktree for the task:
+   ```bash
+   git fetch origin
+   git worktree add -b <type>/<short-task> ../worktrees/<short> origin/v2
+   cd ../worktrees/<short>
+   ```
+3. Work in the worktree — all commits, pushes, and PR work happen here.
+4. Push and open a PR against `v2`.
+5. After CI passes and the PR is merged, clean up:
+   ```bash
+   git worktree remove --force ../worktrees/<short>
+   git branch -D <type>/<short-task>
+   git push origin --delete <type>/<short-task> 2>/dev/null  # OK if already gone
+   git remote prune origin
+   ```
+6. From the main checkout, pull the new `v2` tip:
+   ```bash
+   git -C ../CadeiaDominial pull origin v2
+   ```
+
+### Conventions
+
+- **PR base**: `v2` (or `docs/roadmap-and-pending-decisions` for roadmap/spec updates — see below).
+- **Branch name**: `<type>/<short-task>` (Conventional Commits type: `feat`, `fix`, `docs`, `refactor`, `chore`, …).
+- **PR title**: Conventional Commits subject, e.g. `feat: add JWT-based user authentication`.
+
+### Don't
+
+- **Don't open PRs against `main`** — it exists as a GitHub default but is not the working branch.
+- **Don't commit directly to `v2`** — always go through a worktree + PR. Trivial project-config edits (e.g. `WORKFLOW.md`) are the only exception, and only with explicit user approval.
+- **Don't leave worktrees behind** after a merge. Cleanup is part of the lifecycle, not optional.
+- **Don't put task branches in the main checkout** — use `git worktree add` so parallel work doesn't fight over the working tree.
+- **Don't commit agent scratch files** (e.g. `docs/ERD_*.png` rendered by `mmdr`) — keep them untracked, or use `mmdr`'s `--out` to write elsewhere.
+
+### Long-lived branch: `docs/roadmap-and-pending-decisions`
+
+This branch tracks the roadmap and pending decisions. It is also kept as a long-lived worktree. Do **not** clean it up after a PR — it accumulates multiple task PRs and is periodically merged into `v2`. New roadmap-related task branches fork from `origin/docs/roadmap-and-pending-decisions` instead of `origin/v2`.
+
+`docs/roadmap-and-pending-decisions/TASKS.md` and `SCHEMA_DECISOES_PENDENTES.md` are the authoritative source of pending decisions. Read them before starting any task that might already be tracked.
 
 ## Build, Test, and Development Commands
 
-This repository snapshot is documentation-focused; the TypeScript monorepo described in `README.md`/`docs/MIGRATION_GUIDE.md` is not present here. When working against the full monorepo, the intended commands are:
+This repository snapshot is documentation-focused; the TypeScript monorepo described in `README.md` and `docs/MIGRATION_GUIDE.md` is not present here. When working against the full monorepo:
 
 ```bash
 pnpm dev                       # Start API + web together
-cd packages/web && pnpm dev    # Frontend dev server
-cd packages/api && pnpm dev    # API dev server
-cd packages/api && pnpm db:generate
-cd packages/api && pnpm db:migrate:local
+pnpm -C packages/web dev       # Frontend dev server
+pnpm -C packages/api dev       # API dev server
+pnpm -C packages/api db:generate
+pnpm -C packages/api db:migrate:local
+pnpm test                      # Vitest + Playwright
+pnpm format && pnpm lint
 ```
 
-If you only touch docs, no build step is required.
+If you only touch `docs/`, no build step is required.
 
 ## Coding Style & Naming Conventions
 
 - Documentation is Markdown; keep headings structured and sentences concise.
 - Follow existing naming patterns for docs (e.g., `MIGRATION_GUIDE.md`, `ARCHITECTURE_DECISIONS.md`).
-- The target TypeScript stack (per `docs/MIGRATION_GUIDE.md`) expects ESLint + Prettier, strict TypeScript, and minimal `any` usage.
+- The target TypeScript stack (per `docs/MIGRATION_GUIDE.md`) uses ESLint + Prettier, strict TypeScript, and minimal `any`.
 
 ## Testing Guidelines
 
-- The planned stack uses Vitest and Playwright with an 80% coverage target (see `docs/MIGRATION_GUIDE.md`).
-- No automated test runner is configured in this repository snapshot; treat `old/` as reference-only unless instructed otherwise.
-- For frontend verification (visual or interaction checks), use Agent Browser via `agent-browser` (or `npx @vercel-labs/agent-browser`) and document results in the relevant PRD or progress notes.
+- The planned stack uses Vitest and Playwright with an 80% coverage target.
+- For frontend visual/interaction checks, use Agent Browser (`agent-browser` or `npx @vercel-labs/agent-browser`) and document results in the relevant PRD or progress notes.
 
 ## Commit & Pull Request Guidelines
 
-- Commit history follows Conventional Commits with optional scopes (e.g., `feat:`, `fix:`, `docs:`, `refactor:`).
+- Commit messages follow Conventional Commits, optionally scoped, e.g. `feat(auth): add JWT validation`.
 - Use short, imperative subjects and include context in the body when changes affect migration or architecture.
-- For PRs, include a clear summary, link any relevant issue, and note which docs were updated.
+- PRs include a clear summary, link any relevant issue, and note which docs were updated.
 
 ## Migration & Architecture Notes
 
 - Update `docs/ARCHITECTURE_DECISIONS.md` when making material architecture changes.
 - Use `docs/legacy-django/` to cross-reference legacy behaviors during migration work.
-- React Flow is the chosen tree visualization library; reference `docs/MIGRATION_GUIDE.md` for usage notes and `docs/ARCHITECTURE_DECISIONS.md` for the decision record.
-
-## AI Agent Workflows
-
-This repository uses multiple AI agent systems for different development workflows:
-
-### Claude Code (.claude/) - ADD Workflow
-
-Issue-based Agent-Driven Development workflow for implementing features and fixes.
-
-**Usage**: See `.claude/CLAUDE.md` for full documentation
-
-```bash
-/init 123        # Initialize issue workspace
-/research        # Analyze codebase
-/spec           # Write specification
-/tests          # Design tests
-/plan           # Codex: Generate implementation plan (10min)
-/dev            # Implement code
-/review         # Codex: Code review (10min)
-/qa             # Run tests (Playwright + unit)
-```
-
-**Approval**: `git commit artifact.md` = phase approved
-
-### Codex (.codex/) - PRD Workflow
-
-Document-based development using PRD JSON files for bootstrapping the monorepo.
-
-**Skills**:
-
-- `plan-prd` - Create implementation roadmap from PRD JSON
-- `implement-prd` - Execute PRD requirements
-- `review-implementation` - Review changes for correctness and risks
-
-**Files**: `docs/prd/bootstrap/*.json`, `BOOTSTRAP_PROGRESS.md`
-
-### When to Use Which
-
-- **ADD (.claude)**: GitHub issues, bug fixes, feature requests
-- **PRD (.codex)**: Strategic bootstrap tasks, PRD-driven development
-
-Both workflows can run in parallel without conflict.
+- React Flow is the chosen tree visualization library; see `docs/MIGRATION_GUIDE.md` for usage notes.


### PR DESCRIPTION
## Summary
- Adds a `Development Workflow` section to `AGENTS.md` (auto-loaded by every agent session that starts in this checkout or any of its worktrees).
- Documents the one-main-checkout + one-worktree-per-task layout using only **relative paths** (no machine-specific paths like `~/dev/...`) — the file is portable across any clone location.
- Spells out the conventions table and the full lifecycle: spawn on `v2` → create worktree → work → push → PR → CI → merge → worktree cleanup → pull `v2` in the main checkout.
- Explicitly calls out the long-lived `docs/roadmap-and-pending-decisions` branch (kept across tasks, not cleaned up post-merge).
- Cross-references the `github-pr-workflow` skill §1 (worktree setup) and §8 (post-merge cleanup).

## Why
The previous `AGENTS.md` had project-structure info but no workflow lifecycle. Agents had to infer the worktree-per-task pattern from the skill and from prior messages. This PR makes it explicit and auto-loaded, so every new session knows the rules without searching.

It also removes hard-coded machine paths (`~/dev/cadeia-dominial/...`) — the file should work on any machine and any clone location.

## Best-practices references consulted
- https://agents.md/ — the open standard (used by 60k+ projects, supported by Amp, opencode, Codex, Cursor, VS Code, Jules, etc.)
- `openai/codex/AGENTS.md` (286 lines) — detailed code style + project structure
- `withastro/astro/AGENTS.md` (155 lines) — structured H2 sections: style, env, structure, commands
- `astral-sh/uv/AGENTS.md` (20 lines) — terse bullet conventions; the gold standard for brevity

## Changes from the previous AGENTS.md
- **Removed**: hard-coded paths (`~/dev/cadeia-dominial/...`), the giant absolute-path project tree, the Symphony Kanban / `.claude/` / `.codex` tool-internals section (those belong in tool-specific docs, not the agent file)
- **Kept**: project layout, conventions, full lifecycle, the "Don't" list, the long-lived `docs/roadmap-and-pending-decisions` branch exception
- **Added**: post-merge `git pull origin v2` step (Greptile review feedback) so the main checkout stays in sync
- **Length**: 164 → 100 lines

## Test Plan
- [x] `AGENTS.md` is in `CadeiaDominial/AGENTS.md` and propagates to all worktrees (worktrees inherit the file from their base branch)
- [x] `grep -E "~/|/root/|/Users/" AGENTS.md` returns no matches
- [x] The v2 / main distinction is explicit and stated in 4+ places
- [ ] After merge: re-pull `v2` in any open sessions; the new section auto-loads

## Related
- Skill update: `github-pr-workflow` v1.1.0 → v1.2.0 (new §1 'Worktree Setup' and §8 'Post-Merge Worktree Cleanup').
- See also: `WORKFLOW.md` (Symphony config), `docs/roadmap-and-pending-decisions/TASKS.md` (authoritative task source).