### PR TITLE
docs: fix stale path references after T-403 doc rename and AGENTS.md path policy

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -106,10 +106,10 @@ No. SQLite is file-based; we can open the database file directly from a Node.js 
   - Cycle prevention (visited set) to avoid infinite loops.
 
 ### Logic Inspiration (legacy docs)
-- Use the D3 flow docs as the reference for the core graph logic and levels:
-  - `docs/cadeia-dominial/D3_CHAIN_VISUALIZATION_FLOW.md`
-  - `docs/cadeia-dominial/ANALISE_FLUXO_D3.md`
-  - `docs/cadeia-dominial/DOCUMENTACAO_VISUALIZACAO_D3.md`
+- Use the D3 flow docs as the reference for the core graph logic and levels (consolidated into `docs/domain/` as part of the T-403 doc rename):
+  - `docs/domain/visualization-d3.md`
+  - `docs/domain/visualization-d3-analysis.md`
+  - `docs/domain/visualization-d3-reference.md`
 
 ## Implementation Steps
 1. **Schema recon**: Write a small script to list tables + sample columns via `PRAGMA table_info` to confirm names.

--- a/docs/SCHEMA_V2_BLINDSPOT_REVIEW.md
+++ b/docs/SCHEMA_V2_BLINDSPOT_REVIEW.md
@@ -334,7 +334,7 @@ The plan says "auth out of scope" but `users` is in the current Drizzle schema. 
 
 ### 6.7 [P2] The dump file is in the repo working dir (not gitignored by path)
 
-`.gitignore` excludes `*.sql`, but the file is at `~/CadeiaDominial/data.cleaned.core.no-auth.no-unistr.sql` (the project root). **Action:** double-check with `git status` that it shows as ignored. If `git status` shows it under "untracked," add a more specific rule.
+`.gitignore` excludes `*.sql`, but the file is at `<project-root>/data.cleaned.core.no-auth.no-unistr.sql` (the project root). **Action:** double-check with `git status` that it shows as ignored. If `git status` shows it under "untracked," add a more specific rule.
 
 ---
 


### PR DESCRIPTION
## What

Two unrelated 1-line doc fixes, bundled into one PR because they are both stale-path cleanup from the same sweep.

### Fix 1: `docs/SCHEMA_V2_BLINDSPOT_REVIEW.md` §6.7
Replace `~/CadeiaDominial/data.cleaned.core.no-auth.no-unistr.sql` with the placeholder `<project-root>/data.cleaned.core.no-auth.no-unistr.sql`.

- Why: the new `AGENTS.md` ("Project Layout") forbids machine-specific paths in shared docs. The blindspot review was written before that rule existed, but the rule applies retroactively because the doc lives in the repo.

### Fix 2: `PLAN.md` §Logic Inspiration
The three D3 flow docs that `PLAN.md` points at (`D3_CHAIN_VISUALIZATION_FLOW`, `ANALISE_FLUXO_D3`, `DOCUMENTACAO_VISUALIZACAO_D3`) were **removed** in T-403 (PR #17, merged) and consolidated into `docs/domain/visualization-d3{,-analysis,-reference}.md`. The PLAN.md bullets referenced deleted files.

- This was a **broken reference** — anyone following the plan would have hit 404s. Now points to the live files.

## Why bundled

Both are 1-line doc-only fixes on `v2`, both discovered in the same path-policy sweep, both touch `docs/` (no build step needed per AGENTS.md). Two PRs would have been over-engineering for a doc sweep. The fixes are independent and reviewable separately in the diff.

## Test plan
- [x] Diff inspected: `git diff` on the worktree shows only the two intended changes.
- [x] No file under `docs/` references the old paths anymore (verified by manual grep during the sweep).
- [ ] Visual review of the rendered docs.