### PR TITLE
docs(db): schema v2 decisions, ERD, D1-D4 + T1-T4 + round-2 fixes

### DIFF
--- a/docs/db/CODEX_CRITIQUE_2026-06-03.md
+++ b/docs/db/CODEX_CRITIQUE_2026-06-03.md
@@ -1,0 +1,108 @@
+# Codex Critique 2026-06-03 — Cadeia Dominial v2 Schema (Q1-Q15 + Q11b + ERD)
+
+> Gerado por Codex gpt-5.5 (reasoning: high) lendo `docs/db/SCHEMA_DECISOES_PENDENTES.md` + `docs/db/erd-v2.mmd`. Tokens: 104,514. Verdict: **NEEDS REWORK, medium severity**.
+
+## 1. Q11b é direcionalmente correto, mas `cri` precisa de unicidade canônica
+
+A constraint em si está certa para a regra "matrícula 12345 no 1º CRI Salvador != matrícula 12345 no 2º CRI Salvador":
+
+```sql
+documento {
+  int cri_id FK
+  text tipo
+  text numero
+  UNIQUE (cri_id, tipo, numero)
+}
+```
+
+Mas `cri` tem `cns_codigo` como "TBD" sem unicidade visível. Se usuários podem criar linhas duplicadas pro mesmo CRI, o UNIQUE do documento é burlado atribuindo o mesmo documento a dois `cri.id` duplicados. Adicionar um UNIQUE ativo real pra `cri`, idealmente CNS quando disponível.
+
+**Refs:** `erd-v2.mmd:31-40`, `SCHEMA_DECISOES_PENDENTES.md:611-617`
+
+## 2. Evidência pode ser perdida normalizando números de origem/documento agressivamente
+
+O doc diz que o número do documento tem formato rígido e "cartório não erra nesse campo" — a suposição mais arriscada do design dado o contexto de grilagem.
+
+```mmd
+documento.numero     "normalizado, so digitos"
+documento.numero_raw "valor original, so para referencia"
+origem.numero        "so digitos"  // ⚠️ SEM numero_raw!
+```
+
+`documento` ao menos tem `numero_raw`; `origem` não tem. Citações de origem são exatamente onde certidões divergentes podem expor fraude. Se uma certidão diz um número de origem de jeito esquisito/errado/sufixo, `origem.numero` "só dígitos" pode apagar evidência. Mínimo: preservar verbatim origin number separado do normalized searchable number.
+
+**Refs:** `erd-v2.mmd:79-80`, `erd-v2.mmd:153`
+
+## 3. Atores de audit estão confundidos com Pessoas do domínio
+
+O ERD usa `pessoa` tanto pra pessoas que aparecem em registros cartorários quanto pra pesquisadores que executam ações no sistema:
+
+```mmd
+pessoa ||--o{ lancamento_move_event : "moved_by"
+audit_log.actor_id FK "pessoa que executou"
+anotacao_versao.created_by_id FK "pessoa"
+```
+
+Isto vai morder. Um João da Silva no cartório não é o mesmo tipo de entidade que uma conta de pesquisador. Manter `pessoa` de domínio pra registros copiados; usar `user`/`pesquisador` separado pra audit.
+
+**Refs:** `erd-v2.mmd:25`, `erd-v2.mmd:180`, `erd-v2.mmd:204`
+
+## 4. Q13 resolve documentos compartilhados, mas sub-especifica constraints ativo/atual
+
+A junction N:N é o movimento certo. Edge cases ainda precisam constraints de migração:
+
+- **active pair uniqueness:** `(imovel_id, documento_id) WHERE deleted_at IS NULL`
+- **provavelmente um único current per imóvel:** `(imovel_id) WHERE is_documento_atual = 1 AND deleted_at IS NULL`
+- **decidir se um Lancamento MOVIDO pra um Documento compartilhado por 3 imóveis deve aparecer nas 3 chains.** Sob a regra Q13 "belongs equally", sim, mas a UX precisa deixar esse blast radius explícito.
+
+**Refs:** `SCHEMA_DECISOES_PENDENTES.md:706-735`, `erd-v2.mmd:65-74`
+
+## 5. Q14 append-only MOVE é defensível, mas invariantes de current-state estão faltando
+
+Não é over-engineering automático. Se `lancamento.documento_id` significa "onde o registro copiado originalmente vivia", então event-sourcing MOVE é apropriado. **Mas a regra atual é UI-derivada e frágil.** Você precisa de lógica determinística de current-location: order by `(moved_at, id)`, enforce `from_documento_id` = current document no momento do move, e prevenir dois latest moves competidores. Senão em 2 anos você vai debugar lançamentos fantasma. Uma **SQL view ou projection mantida** basta; não precisa de arquitetura nova.
+
+**Refs:** `SCHEMA_DECISOES_PENDENTES.md:761-787`, `erd-v2.mmd:184-194`
+
+## 6. Q15 recomendação: escolher D, com "órfão" como estado derivado
+
+Dado Q13 e Q12, B não deve ser default. A é fraco demais (esconde delete global). C é aceitável, mas D é a escolha limpa:
+
+```
+D está em N chains:
+- default: desvincular desta cadeia
+- admin-only: apagar globalmente
+- if no active imovel_documento remains: D is orphaned
+```
+
+**Caveat importante:** "órfão" deve ser **derivado** de `NOT EXISTS active imovel_documento`, não uma mutação destrutiva automática.
+
+**Refs:** `SCHEMA_DECISOES_PENDENTES.md:798-816`
+
+## 7. Apêndice SQLite/D1 está no caminho certo, mas incompleto pra migrations reais
+
+**Correto:** D1 suporta FTS5, FK PRAGMAs, partial indexes (per Cloudflare docs).
+
+**Faltando:**
+- SQLite/D1 não tem `NOW()` do PostgreSQL; app deve escrever UTC ISO8601 ou usar funções datetime do SQLite consistentemente.
+- FTS5 precisa de sync strategy: triggers ou rebuild/update path explícito.
+- FK actions devem ser explícitas nas migrations; Mermaid não pode mostrar `ON DELETE`.
+- Datas copiadas do cartório podem ser parciais/incertas; strict ISO date fields forçam precisão falsa.
+
+## 8. Mermaid esconde o bastante pra mascarar bugs reais do schema
+
+O ERD usa colunas fake tipo:
+
+```mmd
+text UNIQUE_NOTE "UNIQUE (cri_id, tipo, numero)"
+text UNIQUE_NOTE "UNIQUE (documento_id, numero_lancamento)"
+```
+
+Isto é OK como documentação, mas perigoso se alguém tratar o ERD como schema. A **migration Drizzle deve ser canônica** pra UNIQUE, partial UNIQUE, CHECK, FK actions, triggers, e indexes. Mermaid também não pode mostrar filtros de soft-delete ou constraints "current".
+
+**Refs:** `erd-v2.mmd:93`, `erd-v2.mmd:133`, `erd-v2.mmd:159`
+
+---
+
+## Verdict
+
+**NEEDS REWORK, medium severity.** A direção conceitual é sólida: Q11b FK direto é correto, Q13 N:N é correto, Q14 append-only é defensível. Os blockers são nível-implementação mas importantes: **unicidade canônica do CRI, preservação verbatim dos números de origem, identidade separada de pesquisador, e current/partial constraints explícitos antes de T-101 migrations**.

--- a/docs/db/CODEX_CRITIQUE_2026-06-03_ROUND2.md
+++ b/docs/db/CODEX_CRITIQUE_2026-06-03_ROUND2.md
@@ -1,0 +1,86 @@
+# Codex Critique 2026-06-03 — Round 2
+
+> Crítica rodada por Codex gpt-5.5 (xhigh reasoning) em 2026-06-03 sobre o ERD v2 + SCHEMA_DECISOES_PENDENTES.md após aplicação de D1-D4 + T1-T4.
+
+## Verdict
+
+**NEEDS-MINOR-FIXES** — 2 BLOCKERS, 1 NICE-TO-HAVE, 4 inconsistências textuais.
+
+Direção conceitual permanece sólida. Erros são nível-documentação (campo errado, FK faltando, snippet obsoleto).
+
+## Round 1 Closure Check (1-8)
+
+| # | Achado round 1 | Endereçado? |
+|---|---|---|
+| 1 | CRI active uniqueness | ✅ `cri.UNIQUE_NOTE` documenta partial UNIQUE; apêndice inclui `uq_cri_cns` |
+| 2 | Raw origin/document numbers | ✅ `origem.numero_raw` presente; `documento.numero_raw` mantido |
+| 3 | User vs pessoa identity | ⚠️ **PARCIAL** — MOVE/audit/editor agora usam `user`, mas `anotacao_versao.autor_original_id` ainda aponta para domain `pessoa` (F1 abaixo) |
+| 4 | Q13 active/current constraints | ✅ `imovel_documento` tem metadata per-pair + ambos partial UNIQUE documentados |
+| 5 | Q14 current-location invariant | ⚠️ **PARCIAL** — eventos append-only + `v_lancamento_current_location` documentados; **falta invariante write-time** de que `from_documento_id` = current location |
+| 6 | Q15 orphan mode | ✅ `v_documento_orfao` documentado, nenhuma coluna `is_orfao` aparece |
+| 7 | SQLite/D1 appendix | ⚠️ **PARCIAL** — types, `NOW()`, FTS5, partial indexes cobertos; **FK actions incompletas** apesar de a doc afirmar "toda FK precisa de onDelete explícito" |
+| 8 | Mermaid is not schema | ✅ T4 disclaimer aparece no ERD, legend, e decisions doc |
+
+## New Findings
+
+### F1 — BLOCKER — Annotation authorship aponta para entidade errada
+
+**Q9 é "researcher attribution"** — pesquisadores criam/editam/removem anotações. O ERD atualmente documenta `anotacao_versao.autor_original_id` como `PESSOA` (cartório), mas a pergunta Q9 fala de **pesquisador** criando a anotação. Isso contradiz a separação D3 de `user` vs `pessoa`.
+
+**Ação:**
+- Mudar `anotacao_versao.autor_original_id` de `pessoa_id` (FK) para `user_id` (FK)
+- Atualizar visual edge: `pessoa ||--o{ imovel_documento : "anotou"` está **errado geometricamente** — o FK mora em `anotacao_versao`, não em `imovel_documento`
+- Corrigir para: `user ||--o{ anotacao_versao : "autor_original (Q9=C, imutavel)"`
+- Manter `user ||--o{ anotacao_versao : "created_by (D3, editor, pode diferir do autor original)"` (já existe)
+
+**Justificativa (de Q9):** *"Pesquisadores de grilagem ingerem dados públicos de cartórios (read-only) e adicionam anotações analíticas próprias."* — o "quem" da anotação é o pesquisador, não uma pessoa do cartório.
+
+### F2 — BLOCKER — `anotacao_versao` é documentada como soft-deletable mas falta `deleted_at`
+
+A legend (linha 96) diz: *"deleted_at (Q2=B): presente em imovel, documento, lancamento, lancamento_pessoa, imovel_documento, pessoa, anotacao_versao, cri."* — mas a definição da tabela `anotacao_versao` no .mmd não tem `deleted_at`.
+
+**Ação:**
+- Adicionar `text deleted_at "soft-delete (Q2=B)"` à definição de `anotacao_versao` no .mmd
+- Documentar a interação com `is_current`: soft-delete da anotação inteira (todas as versões) vs `is_current=0` numa versão específica (marca como não-atual, mas mantém no histórico)
+
+### F3 — NICE-TO-HAVE — T3 FK-action coverage + visual FK coverage ainda incompletas
+
+**FK actions faltando no apêndice (T3):**
+- `lancamento.tipo_id` → `lancamento_tipo.id`
+- `anotacao_versao.created_by_id` → `user.id` (D3)
+- `anotacao_versao.operation_id` → `audit_log.id`
+- `lancamento_move_event.audit_log_id` → `audit_log.id`
+- `origem.documento_id` → `documento.id`
+- `tis.terra_referencia_id` → `terra_indigena_referencia.id`
+
+**Relacionamento visual faltando:**
+- `lancamento_tipo ||--o{ lancamento` — `lancamento.tipo_id FK` existe; a legend descreve "classifica"; mas o .mmd não tem a edge
+
+**Ação:**
+- Completar a tabela de FK actions
+- Adicionar `lancamento_tipo ||--o{ lancamento : "classifica (tipo_id)"` ao .mmd
+
+## Schema Inconsistencies (textuais, não estruturais)
+
+1. **Q2 section still recommends Option C, while final decisions table says Q2 is Option B.** — Verificar que o `### ✅ Recomendação` de Q2 (linha ~170) diz "Opção C" mas a tabela de Decisões (linha ~879) diz "**B**". A recomendação foi escrita antes da decisão final.
+2. **Decisions intro still says Q15 is open, while Q15 is later decided as D.** — Já corrigido em "Próximos passos" mas a intro do Q1 (linha 5) diz "10 deles não podem ser resolvidos sem decisão humana. São as 6 perguntas abaixo (Q1 a Q6)" — incoerente com 15 perguntas decididas.
+3. **Q11b "schema final" snippet still shows `documento.imovel_id` and `documento.is_documento_atual`** — Q13 remove ambos para `imovel_documento`. Snippet obsoleto.
+4. **Q14 invariante write-time faltando** — `lancamento_move_event.from_documento_id` deve ser igual ao `current_documento_id` ANTERIOR ao MOVE. Sem CHECK, um bug pode inserir move event com `from` errado. Documentar como invariante (no CHECK constraint ou na app).
+
+## Q14 / Q15 Invariant Check (revisitado)
+
+- ✅ `lancamento` não tem `current_documento_id` coluna (preserva Q14 append-only)
+- ✅ Sem FK de "back-reference" para L movido (UI sempre consulta `v_lancamento_current_location`)
+- ✅ Sem `is_orfao` flag (Q15=🅳️ corretamente usa view)
+
+## Specific Line Citations
+
+- F1: `docs/db/erd-v2.mmd:19-20`, `:34`, `:192-202`; `docs/db/erd-v2-legend.md:78-80`, `:99`; `docs/db/SCHEMA_DECISOES_PENDENTES.md:529-542`
+- F2: `docs/db/erd-v2.mmd:192-203`; `docs/db/erd-v2-legend.md:96`, `:101`; `docs/db/SCHEMA_DECISOES_PENDENTES.md:529-532`, `:911`
+- F3: `docs/db/erd-v2.mmd:15-38`, `:116-141`, `:202-213`, `:233`; `docs/db/SCHEMA_DECISOES_PENDENTES.md:975-995`
+- Q14 write-time invariant: `docs/db/SCHEMA_DECISOES_PENDENTES.md:761-807` (Q14 section)
+- Q15: `docs/db/SCHEMA_DECISOES_PENDENTES.md:846-879` (Q15=🅳️ section)
+
+## Recommended Action
+
+Aplicar F1, F2, F3 + as 4 inconsistências textuais antes do PR. **Espera-se** re-renderizar o ERD e fazer nova crítica round 3 (esperado: READY-TO-MERGE).

--- a/docs/db/SCHEMA_CONSOLIDATED.md
+++ b/docs/db/SCHEMA_CONSOLIDATED.md
@@ -1,5 +1,14 @@
 # Schema Consolidado (v2) - Cadeia Dominial
 
+> **⚠️ SUPERSEDED (2026-06-03, round 3 do T-001).** Este documento é histórico/proposta de consolidação e **NÃO** está alinhado com as decisões finais Q1-Q15 + Q11b + D1-D4 + T1-T4 (PR #24). Continua referenciando campos removidos (`documento.imovel_id`, `documento.is_documento_atual`, `cartorio_transmissao_id`) que foram movidos ou eliminados pelas decisões da PR #24.
+>
+> **Fontes canônicas atuais:**
+> - Decisões + apêndice SQLite/D1: [`docs/db/SCHEMA_DECISOES_PENDENTES.md`](./SCHEMA_DECISOES_PENDENTES.md)
+> - Diagrama visual: [`docs/db/erd-v2.mmd`](./erd-v2.mmd) (note: Mermaid é documentação visual, não schema; UNIQUE_NOTE/CHECK constraints não são enforcem pelo .mmd)
+> - Migration executável: **T-101 (Drizzle, ainda não escrita)**
+>
+> Próximo passo: ou (a) reescrever este arquivo para refletir as decisões da PR #24, ou (b) removê-lo. A migration T-101 will replace both this file and the legacy `DATABASE_SCHEMA.md`/`SCHEMA_IMPROVEMENT_PROPOSAL.md` com um único Drizzle schema versionado.
+
 **Objetivo:** consolidar todas as propostas de melhoria em um único documento coerente, pronto para migração de dados do banco atual para um novo esquema limpo, com foco em SQLite.
 
 **Fontes consolidadas:**

--- a/docs/db/SCHEMA_DECISOES_PENDENTES.md
+++ b/docs/db/SCHEMA_DECISOES_PENDENTES.md
@@ -2,7 +2,7 @@
 
 > **Quem deve ler isso:** Luandro (decisor final), Hiure (implementador), e qualquer pessoa que queira entender por que o schema v2 está do jeito que está. Este documento é em português para ser acessível a pessoas não-desenvolvedoras, mas mantém a precisão técnica.
 >
-> **Por que este documento existe:** A revisão cega do schema v2 (em `docs/SCHEMA_V2_BLINDSPOT_REVIEW.md`) encontrou 27 pontos cegos. Dez deles não podem ser resolvidos sem uma decisão humana. São as 6 perguntas abaixo (Q1 a Q6). **Nenhuma linha de código do schema novo pode ser escrita enquanto essas 6 perguntas não forem respondidas.**
+> **Por que este documento existe:** A revisão cega do schema v2 (em `docs/SCHEMA_V2_BLINDSPOT_REVIEW.md`) encontrou 27 pontos cegos. Dez deles não podem ser resolvidos sem uma decisão humana. **A partir da sessão de grupo de 2026-06-02/03 com Luandro (decisor) e Hiure (implementador), 15 perguntas (Q1–Q15, mais a Q11b) foram decididas.** A Crítica Codex 2026-06-03 (gpt-5.5, high) encontrou 8 blockers; o round 2 pós-D1–D4 + T1–T4 encontrou mais 2 BLOCKERS e 1 nice-to-have — todos resolvidos antes do PR.
 
 ## Contexto rápido
 
@@ -168,7 +168,7 @@ WHERE id = 555;
 **🌳 Como fica no grafo:** O nó da pessoa mostra "[REMOVIDO]" em vez do nome. A cadeia **continua navegável** porque o id existe.
 
 ### ✅ Recomendação
-**Opção C (soft-delete + anonimização LGPD)** — é a única que atende simultaneamente a auditoria jurídica **e** a LGPD sem comprometer a navegação do grafo. A maioria dos sistemas brasileiros de cartório está indo por esse caminho.
+**Opção C (soft-delete + anonimização LGPD)** é a melhor prática geral — é a única que atende simultaneamente a auditoria jurídica **e** a LGPD sem comprometer a navegação do grafo. A maioria dos sistemas brasileiros de cartório está indo por esse caminho. **Mas no contexto do v2 (Cadeia Dominial = sistema de pesquisadores de grilagem que copiam dados do cartório verbatim), a Opção B foi escolhida** (ver tabela de Decisões): `Pessoa` só tem `nome` (sem CPF/RG/email/telefone), então anonimização completa (C) não se aplica. Soft-delete (B) preserva divergências entre certidões como **evidência de grilagem**. Hard-delete (A) vira ainda mais perigoso com esse contexto.
 
 ---
 
@@ -493,38 +493,709 @@ Só 1 nó folha visível (o "atual"). Os outros 2 fins de cadeia do exemplo ante
 
 ---
 
+## Q7 — Cross-chain delete behavior (UX menu) — bloqueia T-105
+
+### 🤔 A pergunta
+Um Documento pode ser `is_documento_atual=true` para N Imóveis E `origem.documento_id` para M outros Lancamentos. Quando o usuário clica "remover" num Lancamento ou Documento compartilhado entre múltiplas chains, qual o menu da UI?
+
+### ⚖️ As opções
+
+- **🅰️ Menu: [Editar] [Soft-delete]** — sem "Mover", sem hard-delete na UI
+- **🅱️ Menu: [Editar] [Mover] [Soft-delete]** — sem hard-delete na UI principal; "Mover" como botão distinto
+- **🅲️ Menu: [Editar] [Soft-delete (com blast radius)]** — confirmação rica no dialog (Q12=🅳️)
+
+### ✅ Decisão
+- **Q7a = 🅱️** (Hiure, 2026-06-02) — Menu: [Editar] [Mover] [Soft-delete]. "Mover" precisa ser um botão distinto pra dar confiança ao usuário de que o trabalho não vai ser perdido. Hard-delete é admin-only, fora do menu padrão.
+
+---
+
+## Q8 — Restore semantics (após Q7b=🅱️)
+
+### 🤔 A pergunta
+GIVEN Q7b=🅱️ (soft-delete conservador: só I + junctions, L's preservados), qual o comportamento do restore?
+
+### ⚖️ As opções
+
+- **🅰️ Restore simétrico** (recomendação) — undo exato do Q7b=B
+- **🅱️ Restore cascata reverso** — restore I + cascade em L's (não se aplica com Q7b=B)
+- **🅲️ Restore minimal** — só I.deleted_at = NULL. Junctions ficam "pendentes"
+- **🅳️ Restore com revisão de pares** — usuário confirma cada junction/L individualmente
+
+### ✅ Decisão
+- **🅰️** (Hiure, 2026-06-03) — simétrico ao Q7b=B, intuitivo ("restaurar = desfazer").
+
+---
+
+## Q9 — Trilha de análise do pesquisador (researcher attribution)
+
+### 🤔 A pergunta
+Pesquisadores de grilagem ingerem dados públicos de cartórios (read-only) e adicionam anotações analíticas próprias. Quando um pesquisador cria/edita/remove uma anotação, o sistema deve rastrear **quem, quando, e qual era o conteúdo antes**?
+
+### ⚖️ As opções
+
+- **🅰️ Sem trilha** — última versão ganha
+- **🅱️ Histórico de versões por anotação** — cada edit salva uma versão
+- **🅲️ Histórico + provenance de criação** — registra também quem criou originalmente
+- **🅳️ Tudo de C + exportação logada** — cada export (PDF, CSV, JSON) registra chain-of-custody
+
+### ✅ Decisão
+- **🅲️** (Hiure, 2026-06-03) — provenance de criação é crítica em equipe (autor original vs editor).
+
+---
+
+## Q10 — Raw vs normalized em campos string com variação real de cartório
+
+### 🤔 A pergunta
+`documento.numero` tem formato rígido (`<M|T>` + número) — não tem `_raw` ali (cartório não erra nesse campo). Mas outros campos têm variação real entre certidões:
+
+- `documento.outorgante_nome`, `documento.outorgado_nome` — "João da Silva" vs "JOÃO DA SILVA" vs "João da Silva Santos"
+- `documento.endereco` — "Rua S. João, 100" vs "Rua São João, n. 100"
+- `lancamento.descricao` — texto livre
+- `documento.cartorio_nome` — "1º Cartório de Registro de Imóveis" vs "1o. Cart. Reg. Imóveis"
+
+O padrão `campo_raw` (verbatim) + `campo` (normalized pra busca) deve ser aplicado?
+
+### ⚖️ As opções
+
+- **🅰️ Não** — versão única basta
+- **🅱️ Sim, em todos os campos variáveis** — `_raw` + normalized em cada
+- **🅲️ Sim em B, mais flag `has_significant_variation`** — marca campo pra revisão quando raw ≠ normalized significativamente
+- **🅳️ Tudo de C, mais detecção de discrepância entre certidões** — quando o MESMO imóvel tem certidões com strings diferentes, marca como discrepância (potencial grilagem)
+
+### ✅ Decisão
+- **🅰️ com exceção de `cartorio_nome`** (Hiure, 2026-06-03).
+- Pros outros campos (nomes, endereços, descrições), busca fuzzy full-text sem `_raw`/`_normalized` é suficiente.
+- **Mas `cartorio_nome` é o único onde a busca exata + normalização tem valor sistêmico** (cruzar certidões que citam o mesmo cartório).
+
+### Implicação estrutural (Hiure, 2026-06-03)
+`cartorio` vira **entidade própria** (tabela `cartorio`), não string field em `documento`:
+
+- `cartorio` table com campos espelhando a API do **Sistema Nacional de Cartórios** (schema TBD)
+- **Source 1 (preferencial):** API lookup → preenche/normaliza `cartorio` automaticamente
+- **Source 2 (fallback):** cadastro manual pelo pesquisador, com os mesmos campos da API
+- `documento.cartorio_id` é FK pra `cartorio.id`
+- Sem campo "outros" / texto livre — pesquisador preenche a mesma estrutura da API
+
+> **⚠️ Q11b (NOVA — Hiure, 2026-06-03):** refinamento da decisão. Ver seção dedicada abaixo.
+
+---
+
+## Q11b (NOVA, schema:) — Refinamento da Q10 sobre `cartorio` / `cri` / `cartorio_transmissao`
+
+> **Contexto:** Q10 decidiu que `cartorio` é entidade própria. Q11b refina **COMO** essa entidade se relaciona com Documento, Lancamento e Origem — surgiu de dúvidas de implementação (Jun 2026).
+
+### 🅰️ `lancamento.cri_origem_id` separado?
+**Pergunta:** Lancamento precisa de uma coluna própria `cri_origem_id` (FK pra `cri`), separada do `origem.cri_id`?
+
+**Resposta (Hiure, 2026-06-03): NÃO.** O CRI da origem já é capturado por `origem.cri_id` (a Origem do Lancamento já tem seu próprio `cri_id` FK). Lancamento herda isso transitivamente. Adicionar `cri_origem_id` no Lancamento seria duplicação.
+
+### 🅱️ Comarca do imóvel muda ao longo do tempo?
+**Pergunta:** Um Imóvel pode mudar de comarca (CRI) ao longo de sua história? Precisamos de `imovel_cri_historico` (N:N + período)?
+
+**Resposta (Hiure, 2026-06-03): NÃO no v1.** Quando pesquisadores pegam o documento, isso já foi consolidado e não deve mudar. `imovel.cri_id` é fixo (FK direto, sem histórico). Se v2+ precisar, criar `imovel_cri_historico` na hora.
+
+> **Importante (Hiure):** "sempre manter a unicidade de documentos com `cartorio + numero_documento` (M ou T + número)" — constraint de unicidade deve ser pelo par `(cartorio_id, tipo, numero)`, não só pelo número.
+
+### 🅲️ Cada Documento tem 1 CRI só? Ou N:N (junction)?
+**Pergunta:** `documento.cri_id` FK direto, ou junction `documento_cri` (N:N)?
+
+**Resposta (Hiure, 2026-06-03): FK DIRETO. Cada Documento tem 1 CRI só.** Não precisa de junction N:N.
+
+> *"(docs/db/SCHEMA_CONSOLIDATED.md:137) `UNIQUE (cri_id, tipo, numero)` — isso garante que a matrícula 12345 no 1º CRI de Salvador é um documento, e a matrícula 12345 no 2º CRI de Salvador é OUTRO documento distinto. Dois cartórios podem ter a mesma numeração para documentos diferentes e é por isso que a unicidade deve ser pelo par numero + cri_id."* (Hiure, 2026-06-03)
+
+> *Exemplo:* matrícula 12345 no 1º CRI de Salvador = documento 1. Transcrição 12345 no 1º CRI de Salvador = documento 2. Matrícula 12345 no 2º CRI = documento 3. Matrícula 12345 no 1º CRI de Curitiba = documento 4.
+
+### Schema final (Q10 + Q11b)
+
+```
+cri {
+  int id PK
+  text nome "1º Cartório de Registro de Imóveis de Salvador"
+  text cidade
+  text uf
+  text CNS_codigo "Cadastro Nacional de Serventia (TBD)"
+  // ... outros campos espelhando API do Sistema Nacional de Cartórios
+  text created_at
+  text updated_at
+}
+
+documento {
+  int id PK
+  text tipo "CHECK (matricula | transcricao)"
+  text numero "normalizado, só dígitos"
+  text numero_raw "valor original"
+  int cri_id FK                  // FK direto, SEM junction
+  // (Q13) imovel_id REMOVIDO em v2: chain membership foi para imovel_documento junction
+  // (Q13) is_documento_atual REMOVIDO em v2: virou per-par na junction
+  text created_at
+  text deleted_at
+  UNIQUE (cri_id, tipo, numero)  // par cartorio+tipo+numero
+  // (Q10) sem outorgante_nome_raw / outorgado_nome_raw (busca fuzzy FTS5 basta)
+}
+
+imovel {
+  int id PK
+  int cri_id FK                  // fixo, sem histórico no v1
+  int proprietario_id FK
+  int arquivado "0/1"
+  text created_at
+  text deleted_at
+  // (Q11b=🅲️) v1: imovel_id direto no documento (sem junction imovel_documento)
+  //             Q13=N:N com junction vem depois (ver Q13 abaixo)
+}
+
+lancamento {
+  int id PK
+  int documento_id FK
+  int tipo_id FK
+  text cartorio_transmissao_nome "FREE-FORM, sem FK"  // tabelionato de notas
+  text livro_transmissao
+  text folha_transmissao
+  text data_transmissao
+  int numero_lancamento
+  text forma
+  // SEM cri_origem_id (Q11b=🅰️) — CRI da origem vem via origem.cri_id
+  text created_at
+  text deleted_at
+  UNIQUE (documento_id, numero_lancamento)
+}
+
+origem {
+  int id PK
+  int lancamento_id FK
+  int indice "0, 1, 2..."
+  int cri_id FK                  // CRI de origem (Q11b=🅰️: este campo já é o "cri_origem_id")
+  int documento_id FK "opcional"
+  text tipo "matricula | transcricao | fim_cadeia"
+  text numero
+  text livro
+  text folha
+  text data
+  text observacoes
+  UNIQUE (lancamento_id, indice)
+}
+```
+
+---
+
+## Q12 — UX confirmation dialog (obrigatório em T-105)
+
+### 🤔 A pergunta
+Toda operação de delete (soft ou hard) deve passar por um dialog? Que informações o dialog mostra?
+
+### ⚖️ As opções
+
+- **🅰️ Dialog simples "tem certeza?"**
+- **🅱️ Dialog com blast radius** — lista N+M chains, M' Lancamentos afetados
+- **🅲️ Dialog com blast radius + botão "Editar ao invés"**
+- **🅳️ Igual C, mais preview ANTES** — modal read-only read-back do que vai sumir, depois dialog de confirmação
+
+### ✅ Decisão
+- **🅳️** (Hiure, 2026-06-03) — "É importante perguntar ao usuário se ele quer mesmo apagar ou se ele quer só editar alguma informação" (Hiure, 2026-06-02).
+
+### Comportamento final do delete (T-105)
+1. Usuário clica "Apagar" → **modal de preview read-only** lista blast radius; permite CANCELAR ou AVANÇAR
+2. AVANÇAR → **dialog de confirmação**:
+   - Botão padrão (não destrutivo, foco do Enter): **"Editar ao invés de apagar"** → abre form de edição
+   - Botão destrutivo (vermelho, type-to-confirm com nome do registro): **"Apagar mesmo assim"**
+   - Checkbox opcional: "não mostrar preview de novo nesta sessão" (com audit log)
+3. Confirmação → soft-delete (Q7a/B) + audit log (Q9=C) + provenance (Q10)
+
+---
+
+## Q13 — Modelagem de "chain membership" (CRITICAL — v1 tinha bug estrutural)
+
+### 🤔 A pergunta
+v1 (e v2 herdado) tinha `imovel ||--o{ documento : possui`, codificando "este Imóvel é o dono do Documento". Isso é **errado** — a cadeia histórica é **igualmente pertencente** a todos os Imóveis que a citam (matrícula compartilhada entre grileiros disputando, por exemplo).
+
+### ⚖️ As opções
+
+- **🅰️ Manter 1:N** — `documento.imovel_id` direto, "primário" + "shared" como exceção
+- **🅱️ Junction `imovel_documento` (N:N completo)** — Documento perde `imovel_id` direto; chain membership via junction. `is_documento_atual` vira per-par.
+
+### ✅ Decisão
+- **🅱️** (Hiure, 2026-06-02) — *"Não é para ser prioritário de nenhuma cadeia dominial esse histórico. Ele pertence igualmente a diferentes imóveis."*
+
+### Schema (Q13=🅱️)
+```
+imovel ||--o{ imovel_documento : ""
+documento ||--o{ imovel_documento : ""
+imovel_documento {
+  int id PK
+  int imovel_id FK
+  int documento_id FK
+  int is_documento_atual "0/1, per (Imovel, Documento) pair"
+  int delete_operation_id "FK audit_log (Q8=A)"
+  text created_at
+  text deleted_at "soft-delete per chain membership"
+}
+documento {
+  // (Q13) imovel_id REMOVIDO (vai pra junction)
+  // (Q13) is_documento_atual REMOVIDO (vai pra junction, per-par)
+}
+```
+
+### Implicações
+- **T-100:** adicionar `imovel_documento` ao ERD; remover `imovel_id` e `is_documento_atual` de `documento`
+- **T-101:** criar a tabela junction; ajustar FKs
+- **T-300 (legacy-fit):** o legacy Django tinha `documento.imovel_id` (1:N); precisa popular a junction `imovel_documento` na migração
+
+---
+
+## Q14 — Operação MOVE/REASSIGN cross-chain (surgiu do insight do Hiure)
+
+### 🤔 A pergunta
+*"Ela não pode perder esses lançamentos. Eles precisam ser atrelados a outra cadeia dominial. Só enviar ele para outra cadeia dominial de outro imóvel."* (Hiure, 2026-06-02)
+
+O sistema precisa de uma operação MOVE que:
+- ✅ Preserva o Lancamento byte-for-byte (igualdade no MOVE = preservação de evidência)
+- ✅ Torna o Lancamento visível na chain do Documento de destino (D'), sem mutar o L
+- ✅ É auditável — registra o evento de move no log + na tabela append-only `lancamento_move_event`
+- ✅ Trigger de soft-delete no D de origem? Se L é o ÚNICO Lancamento em D, mover L deixa D "órfão". D vira soft-deleted automaticamente? Ou fica "pendente"?
+
+### ✅ Decisão
+- **🅱️ MOVE preserva Lancamento; D de origem fica "pendente"** (Hiure, 2026-06-02) — sem Lancamentos ativos, mas NÃO soft-deletado. Usuário decide depois se quer fechar a chain, reatribuir D, ou deixar pendente.
+
+### Implementação (event-sourced, alinhada com Codex critique 2026-06-03)
+
+**Ação é append-only — o Lancamento NÃO é mutado.**
+
+```
+Tabela lancamento_move_event (append-only, sem updated_at/deleted_at):
+  id
+  lancamento_id     -- FK lancamento
+  from_documento_id -- D origem
+  to_documento_id   -- D destino
+  reason            -- text, obrigatório (Q12=🅳️)
+  moved_by          -- FK user
+  moved_at          -- ISO8601 TEXT
+  audit_log_id      -- FK audit_log; action='MOVE'
+
+Tabela audit_log:
+  operation_id  -- UUID; agrupa todos os moves de uma operação
+  action = 'MOVE'
+  payload_json  -- snapshot do estado pré-move
+```
+
+**Lógica:**
+1. Usuário seleciona um ou mais Lancamentos e clica "Mover para outra cadeia"
+2. UI mostra preview: "L [id] será movido de D [origem] para D' [destino]. L's já existem em D'? Mostra possíveis colisões." (Q12=🅳️)
+3. Usuário confirma
+4. Sistema: cria 1 row em `lancamento_move_event` por Lancamento movido
+5. Sistema: cria 1 row em `audit_log` com `action='MOVE'`, `operation_id=UUID`, `payload_json` snapshot
+6. **Lancamento NÃO é mutado.** PK e FKs originais (incluindo `documento_id`) ficam intactas.
+7. UI consulta `lancamento_move_event` (via view abaixo) para mostrar L na chain de D'.
+8. D de origem fica "pendente" se não tem mais L's ativos apontando pra ele
+
+### View SQL: `v_lancamento_current_location` (T2)
+
+Regra UI-only ("L aparece na chain de D' se existe move event mais recente com `to_documento_id = D'`, OU se L foi criado direto em D'") é frágil — vai gerar "lançamentos fantasma" em 2 anos (Codex critique 2026-06-03 #5). Solução: **view computada** que a UI consulta:
+
+```sql
+CREATE VIEW v_lancamento_current_location AS
+SELECT
+  l.id AS lancamento_id,
+  COALESCE(
+    (SELECT me.to_documento_id
+     FROM lancamento_move_event me
+     WHERE me.lancamento_id = l.id
+     ORDER BY me.moved_at DESC, me.id DESC
+     LIMIT 1),
+    l.documento_id
+  ) AS current_documento_id
+FROM lancamento l
+WHERE l.deleted_at IS NULL;
+```
+
+**Como a UI consome:**
+- "Mostrar L na chain de D" → `JOIN lancamento l ON l.id = ? JOIN v_lancamento_current_location v ON v.lancamento_id = l.id WHERE v.current_documento_id = D`
+- "Quais L's estão em D'?" → query acima
+- "Histórico de moves do L" → `SELECT * FROM lancamento_move_event WHERE lancamento_id = L ORDER BY moved_at, id`
+
+**D1/SQLite support:** `CREATE VIEW` totalmente suportado. Custo: index em `lancamento_move_event(lancamento_id, moved_at DESC, id DESC)` para performance (Drizzle adiciona via `CREATE INDEX` na migration T-101).
+
+**Por que não coluna `current_documento_id` em `lancamento`?**
+- Quebraria Q14=B (append-only) — coluna seria mutada em cada MOVE.
+- Q8=🅰️ (restore simétrico) não conseguiria desfazer via SQL: precisaria salvar estado anterior.
+- View é determinística, sempre bate com `lancamento_move_event`. Custo de cálculo é aceitável para queries de UI.
+
+**Por que append-only (não mutação em `lancamento`)?**
+- **Evidência:** hash/byte do Lancamento é estável através do tempo. MOVE é evento, não mutação.
+- **Auditoria:** histórico completo de moves (um L pode ter sido movido múltiplas vezes).
+- **Restore simétrico (Q8=🅰️):** undo de MOVE = insert de move event reverso.
+- **Time-travel queries:** "onde o L estava em 2025-01-01?" = filtrar `lancamento_move_event` por `moved_at <= X`.
+
+---
+
+## Q15 — Delete de Documento compartilhado entre N Imóveis (surgiu do Codex 2026-06-03)
+
+### 🤔 A pergunta
+Q13 fez `Documento` ser compartilhável entre N Imóveis via junction `imovel_documento`. Q7a=🅱️ diz "soft-delete no menu" mas não distingue:
+- **D está em 1 chain só** (I-exclusive) → soft-delete afeta 1 chain
+- **D está em 3 chains** (shared entre I1, I2, I3) → soft-delete afeta 3 chains
+
+O usuário talvez **não perceba** que está afetando outras 2 chains. A UI precisa deixar isso explícito.
+
+### ⚖️ As opções
+
+- **🅰️ "Desvincular desta cadeia" (default)** — soft-delete só da junction ativa
+- **🅱️ "Apagar globalmente" (admin-only)** — soft-delete do D + TODAS as junctions
+- **🅲️ Two-step: tenta desvincular primeiro** — UI mostra preview: "D está em 3 chains. Opções: (a) Desvincular desta chain, (b) Apagar globalmente (afeta 3 chains)"
+- **🅳️ Igual C, mais "modo D órfão"** — se D fica sem junctions ativas, vira "órfão" automaticamente; UI oferece hard-delete admin-only
+
+### ✅ Decisão
+- **🅳️** (Hiure, 2026-06-03) — default = desvincular desta cadeia; admin-only = apagar globalmente; órfão = derivado de `NOT EXISTS active imovel_documento`.
+
+### Implementação (Q15=🅳️)
+
+**Três ações, três escopos:**
+
+1. **"Desvincular desta cadeia" (default, qualquer usuário)**
+   - Soft-delete **apenas** da row em `imovel_documento` (junction ativa)
+   - `documento` continua existindo, intacto, em outras chains
+   - `lancamento` continua existindo (Q7b=B preserva L)
+   - **Constraint derivada:** `imovel_documento.is_documento_atual` per-par; soft-delete zera `is_documento_atual` se era 1
+   - Partial UNIQUE adicional: `UNIQUE (imovel_id) WHERE is_documento_atual=1 AND deleted_at IS NULL` (T1) — garante no máximo 1 doc atual por Imóvel
+
+2. **"Apagar globalmente" (admin-only)**
+   - Soft-delete do `documento` + soft-delete de TODAS as `imovel_documento` onde ele aparece
+   - `lancamento` preservado órfão (Q7b=B)
+   - Admin vê o blast radius completo antes de confirmar (Q12=🅳️)
+   - Audit log: `action=SOFT_DELETE, entity_type=documento, entity_id=X, payload_json={junctions_affected: [ids...]}`
+
+3. **"D órfão" (estado derivado)**
+   - **Não é coluna.** É uma view computada:
+   ```sql
+   CREATE VIEW v_documento_orfao AS
+   SELECT d.id, d.tipo, d.numero, d.cri_id
+   FROM documento d
+   WHERE d.deleted_at IS NULL
+     AND NOT EXISTS (
+       SELECT 1 FROM imovel_documento id_
+       WHERE id_.documento_id = d.id
+         AND id_.deleted_at IS NULL
+     );
+   ```
+   - UI lista `v_documento_orfao` e oferece: "Reatribuir a imóvel existente" (cria nova junction) | "Hard-delete (admin-only)" | "Deixar pendente"
+
+**Por que estado derivado (não coluna):**
+- Regra UI-only (Codex critique 2026-06-03 #5) é frágil — uma `is_orfao` flag desatualiza se o usuário reatribui
+- View é determinística, sempre correta, custo = scan do índice `imovel_documento.documento_id`
+- D1 (Cloudflare D1 suporta CREATE VIEW; SQLite full support)
+
+### Diagrama de decisão (Q15=🅳️)
+
+```
+Usuário clica "Apagar" em Documento D
+   │
+   ├─ D está em 1 chain? ── SIM ──> "Tem certeza? D afeta 1 chain (I=X)"
+   │                                 [Cancelar] [Apagar]
+   │
+   └─ D está em N chains? ── NÃO ──> "D está em N chains. Opções:"
+                                     [Desvincular desta chain] (default, soft-delete junction)
+                                     [Apagar globalmente] (admin-only, soft-delete D + N junctions)
+                                     [Cancelar]
+```
+
+---
+
 ## Decisões
 
-> 👇 **Esta seção deve ser preenchida por Luandro** com a escolha de cada pergunta. O blocker T-001 do `docs/TASKS.md` só é considerado fechado quando todas as 6 tiverem uma resposta aqui.
+> ✅ **Seção preenchida em 2026-06-02/03** durante sessão de grupo com Luandro (decisor) e Hiure (implementador). Q15 ainda em aberto. As decisões destravam T-001 e liberam o início de T-100 (re-desenhar o ERD aplicando Q1–Q14) e T-101 (schema Drizzle).
+>
+> **Contexto crítico que ancorou várias decisões** (revelado por Hiure durante a sessão): o v2 é usado por um **grupo de pesquisadores investigando grilagem de terras**, não por cartório. Eles copiam dados do cartório pro sistema **exatamente como estão** (inclusive erros), porque **divergências entre certidões são indícios de grilagem**. Sistema = cópia fiel + camada de análise, NÃO uma base "limpa".
 
 | # | Pergunta | Escolha | Justificativa |
 |---|---|---|---|
-| Q1 | Cascade em Imovel | _pendente_ | |
-| Q2 | Soft-delete vs hard-delete | _pendente_ | |
-| Q3 | Cardinalidade OrigemFimCadeia | _pendente_ | |
-| Q4 | PII encryption at rest | _pendente_ | |
-| Q5 | Validação CPF/CNPJ (DB vs app) | _pendente_ | |
-| Q6 | React Flow: atual vs completo | _pendente_ | |
+| Q1 | Cascade em Imovel | **Opção C** (soft-delete + CASCADE admin-only) | Erros de digitação de imóvel são comuns no cartório; histórico precisa continuar auditável (quem lançou, quando, em qual documento). Soft-delete + CASCADE real só via admin resolve isso. |
+| Q2 | Soft-delete vs hard-delete | **Opção B** (coluna `deleted_at` em todas as tabelas relevantes) | LGPD moot: v2 `Pessoa` só tem `nome`. Anonimização (C) não se aplica. Soft-delete (B) preserva divergências entre certidões como **evidência de grilagem** — corrigir "erro" não pode significar perder a string original. Hard-delete (A) vira ainda mais perigoso com esse contexto. |
+| Q3 | Cardinalidade OrigemFimCadeia | **Opção B** (1:N — uma OrigemFimCadeia por origem, como Django) | **Essa é a informação mais importante e precisa ganhar destaque no grafo. A maioria das grilagens vai ser desvendada por ela** (Hiure, 2026-06-02). Cada origem com classificação independente permite ver o mapa granular de legitimidade de uma vez. Não é comum ter >1 origem por Lancamento, mas pode acontecer e precisa estar modelado. |
+| Q4 | PII encryption at rest | **Opção A** (texto puro) | v2 `Pessoa` só tem `nome` (sem CPF/RG/email/telefone), e nome em cartório é público por definição. Usuários são grupo fechado de pesquisadores que precisam buscar/comparar nomes livremente. Criptografia quebraria a busca sem ganho de segurança real. Complexidade de KMS/chave mestra em D1/Cloudflare Workers é custo desproporcional. |
+| Q5 | Validação CPF/CNPJ | **REMOVER** `cpf`/`rg`/`data_nascimento`/`email`/`telefone` de `Pessoa` no v2. Q5b vira N/A. | Coerente com Q2/Q4: v2 não é sistema de PII, é cópia fiel do cartório + análise. Pesquisadores não precisam do CPF dentro do sistema — quem precisa cruza com bases externas (Receita, processos judiciais). Sub-task explícita do T-300: "definir quais colunas descartar do legado no v2". |
+| Q6 | React Flow: atual vs completo | **Opção A** (mostrar todos os fins de cadeia sempre) | Fins de cadeia são a evidência mais crítica pra detecção de grilagem (ancorada em Q3); precisam estar visíveis sempre. A complexidade visual de "cadeia gigante" (centenas de documentos) é resolvida por uma **camada de controles de visualização** (toggle de ramos, colapso de subárvore, filtros por classificação) que vale pra cadeia **inteira** — não só pra fins de cadeia. Essa camada vira **task T-104** (Phase 1.5 do roadmap). |
+| Q7a | Menu delete | **🅱️** [Editar] [Mover] [Soft-delete] | "Mover" precisa ser botão distinto pra dar confiança ao usuário. Hard-delete é admin-only, fora do menu padrão. |
+| Q7b | Cascade delete Imóvel | **🅱️** Cascade conservador: I + junctions, L's preservados | Lancamentos são evidência — devem sobreviver órfãos. Cascade em junctions `imovel_documento` apenas. |
+| Q8 | Restore semantics | **🅰️** Simétrico ao Q7b=B | Intuitivo ("restaurar = desfazer"). Soft-delete foi conservador, nada de "lixo" pra restaurar. |
+| Q9 | Trilha de análise | **🅲️** Histórico + provenance de criação | Crítico em equipe (autor original vs editor). |
+| Q10 | Raw vs normalized | **🅰️** com exceção de `cartorio_nome` | Demais campos variáveis usam busca fuzzy FTS5. `cartorio_nome` vira entidade própria (tabela `cartorio`). |
+| Q11b | Refinamento Q10 sobre `cri` | **Ver Q11b acima** | `cri` table (não genérico `cartorio`); `documento.cri_id` FK direto (sem junction); `UNIQUE (cri_id, tipo, numero)`; `cartorio_transmissao` é campo livre, não tabela; `imovel.cri_id` fixo (sem histórico v1). |
+| Q12 | UX confirmation dialog | **🅳️** preview ANTES + dialog | "É importante perguntar se quer mesmo apagar ou se quer só editar" (Hiure, 2026-06-02). |
+| Q13 | Chain membership | **🅱️** Junction `imovel_documento` (N:N) | "Pertence igualmente a diferentes imóveis" (Hiure, 2026-06-02). `is_documento_atual` per-par. |
+| Q14 | MOVE cross-chain | **🅱️** MOVE preserva Lancamento, D origem "pendente" | Append-only `lancamento_move_event`; Lancamento não é mutado. |
+| Q15 | Delete D compartilhado | **🅳️** Default = desvincular desta chain; admin-only = apagar global; órfão = view computada | "Órfão" como estado derivado (view `v_documento_orfao`) em vez de coluna — sempre correto, regra UI-only seria frágil. D1 suporta CREATE VIEW. |
 
-**Formato sugerido para preencher:**
+### Decisões adicionais derivadas
 
-```markdown
-| Q1 | Cascade em Imovel | **Opção C** (soft-delete + CASCADE) | Permite restaurar cadastros errados sem perder histórico. Auditoria cartorial exige. |
-| Q2 | Soft-delete | **Opção C** (anonimização LGPD) | Único caminho que atende LGPD e mantém navegação do grafo. |
-| Q3 | Cardinalidade OrigemFimCadeia | **Opção B** (1:N, como Django) | Preserva toda informação. Compatibilidade com legado. |
-| Q4 | PII encryption | **Opção A** (texto puro) | Ambiente interno controlado, sem exposição à internet. Decidir de novo se mudar. |
-| Q5 | Validação CPF/CNPJ | **Opção C** (normalizado no banco) | CHECK constraint garante integridade; app valida dígitos. |
-| Q6 | React Flow visualização | **Opção C** (toggle) | Melhor para múltiplos públicos. Custo de UI aceitável. |
+> Estas não estavam nas 6 perguntas originais, mas emergiram naturalmente da discussão.
+
+- **Nova task T-104 — Controles de visualização da cadeia** (toggle de ramos, colapso de subárvore, filtros por classificação, layouts de export PDF/XLSX/PNG). **Bloqueada em T-100 e T-101.** Justificativa: cadeias com centenas de documentos inviabilizam a visualização sem esses controles; precisa ser uma feature de UI/UX própria, não uma escolha binária escondida dentro da Q6. Detalhes no TASKS.md.
+- **Sub-task do T-300 (legacy-fit)** — "Definir e descartar colunas PII do legado". Lista atual: `Pessoas.cpf`, `Pessoas.rg`, `Pessoas.data_nascimento`, `Pessoas.email`, `Pessoas.telefone`. Migrar do Postgres legado (que tem esses campos) pro Drizzle/D1 (que não terá) sem perda funcional.
+- **T-105 (Soft-delete workflow)** — implementação do delete UX (Q7a/B, Q12=🅳️), restore (Q8=🅰️), MOVE (Q14=🅱️), delete de Documento shared (Q15 — bloqueada até decisão). **Bloqueada em T-100/T-101 E na decisão de Q15.**
+
+**Notas finais para implementadores (T-100/T-101):**
+- A tabela acima (linhas de Decisões) é a fonte de verdade. Use-a como referência canônica.
+- Para o contexto crítico (pesquisadores de grilagem, cópia fiel) e a justificativa de cada escolha, ver `docs/db/erd-v2-legend.md` seção 6 e este doc (seções Q1–Q15).
+
+---
+
+## Apêndice: Convenções SQLite/D1 (Codex critique 2026-06-03 — T3 expandido)
+
+Para o schema Drizzle/T-101, as seguintes convenções de tipos são obrigatórias:
+
+| Conceito | Tipo errado | Tipo correto (SQLite/D1) |
+|---|---|---|
+| Boolean | `bool`, `boolean` | `INTEGER` (0/1) com `CHECK (col IN (0,1))` |
+| Date | `date` | `TEXT` ISO8601 (`'2026-06-03'`) |
+| Datetime | `datetime`, `timestamp` | `TEXT` ISO8601 (`'2026-06-03T14:30:00Z'`) |
+| Money | `decimal`, `numeric`, `real` | `INTEGER` em **centavos** (evita rounding errors) |
+| Area | `decimal`, `real` | `INTEGER` em **centiares** (1 are = 100 m²) ou `TEXT` decimal com escala fixa |
+| Enum (ex: `tipo_cartorio`) | `enum` nativo Postgres | `TEXT` com `CHECK (col IN ('CRI','NOTAS','CIVIL','TRANSMISSAO','OUTRO'))` |
+| UUID (operation_id) | n/a | `TEXT` (Drizzle gera UUID v4) |
+| Encrypted blob | n/a | `BLOB` (AES-256-GCM) — **N/A no v2** (Q4=A + Q5=REMOVER PII de Pessoa; v2 não armazena PII) |
+| Hash (cpf_hash) | n/a | `TEXT` (SHA-256 hex) — **N/A no v2** (sem PII para hashear) |
+
+### `NOW()` / timestamps
+
+SQLite/D1 **NÃO** tem `NOW()`. **A aplicação gera o timestamp no app layer** (Node `new Date().toISOString()`) e grava como `TEXT` ISO8601 UTC. Justificativa: testes determinísticos, reprodutibilidade de migrações, sem dependência de clock do servidor.
+
+```ts
+// Padrão na app
+import { randomUUID } from 'crypto';
+const now = new Date().toISOString(); // '2026-06-03T14:30:00.000Z'
+const opId = randomUUID();            // 'f47ac10b-58cc-4372-a567-0e02b2c3d479'
+
+db.insert(auditLog).values({
+  operationId: opId,
+  action: 'CREATE',
+  createdAt: now,
+  // ...
+});
 ```
+
+### FK actions explícitas (Drizzle → ON DELETE)
+
+Toda FK precisa ter `onDelete` explícito. Defaults Drizzle = `NO ACTION` (= RESTRICT em SQLite), o que é raramente o que queremos:
+
+| Relação | onDelete | Justificativa |
+|---|---|---|
+| `documento.cri_id` → `cri.id` | `RESTRICT` | Não pode apagar CRI com docs; admin tem hard-delete separado |
+| `imovel.cri_id` → `cri.id` | `RESTRICT` | Mesmo |
+| `origem.cri_id` → `cri.id` | `RESTRICT` | Mesmo |
+| `lancamento.documento_id` → `documento.id` | `SET NULL` | Q7b=B: L preservado órfão se D sumir |
+| `lancamento.tipo_id` → `lancamento_tipo.id` | `RESTRICT` | Não pode apagar tipo em uso; criar novo + migrate L se necessário |
+| `lancamento_pessoa.lancamento_id` → `lancamento.id` | `CASCADE` | Junction de membership, segue o L |
+| `lancamento_pessoa.pessoa_id` → `pessoa.id` | `SET NULL` | Q2=B: nome_verbatim preservado; LGPD pode apagar P |
+| `imovel_documento.imovel_id` → `imovel.id` | `CASCADE` | Q7b=B: junction segue I |
+| `imovel_documento.documento_id` → `documento.id` | `RESTRICT` | Q15=🅳️: apagar D é admin-only e intencional |
+| `anotacao_versao.imovel_documento_id` → `imovel_documento.id` | `CASCADE` | Junction específica |
+| `anotacao_versao.autor_original_id` → `user.id` | `RESTRICT` | F1: autor original é histórico, não pode virar NULL |
+| `anotacao_versao.created_by_id` → `user.id` | `SET NULL` | Editor pode ser removido, anotação permanece |
+| `anotacao_versao.operation_id` → `audit_log.id` | `SET NULL` | Audit log pode ser purgado (LGPD), anotação preservada |
+| `lancamento_move_event.lancamento_id` → `lancamento.id` | `RESTRICT` | Q14=B: append-only; L é imutável |
+| `lancamento_move_event.from_documento_id` → `documento.id` | `SET NULL` | D pode sumir, evento preservado |
+| `lancamento_move_event.to_documento_id` → `documento.id` | `SET NULL` | Mesmo |
+| `lancamento_move_event.moved_by_id` → `user.id` | `SET NULL` | Pesquisador removido, evento preservado |
+| `lancamento_move_event.audit_log_id` → `audit_log.id` | `SET NULL` | Audit log pode ser purgado, evento preservado |
+| `origem.documento_id` → `documento.id` | `SET NULL` | Origem órfã se D sumir; tipo=fim_cadeia tem NULL anyway |
+| `user.deleted_at` | (no FK) | n/a |
+| `audit_log.actor_id` → `user.id` | `SET NULL` | LGPD: pesquisador pode pedir remoção, log preservado |
+| `audit_log.deleted_at` | (no FK) | n/a |
+| `tis_imovel.*` | `CASCADE` | Junction simples |
+| `tis.terra_referencia_id` → `terra_indigena_referencia.id` | `RESTRICT` | Referência oficial não pode sumir com TIs em uso |
+
+**Invariante Q14 (write-time, no app antes de INSERT):**
+```ts
+// Antes de criar um lancamento_move_event, validar:
+const current = await db.query.v_lancamento_current_location.findFirst({
+  where: eq(v_lancamento_current_location.lancamento_id, payload.lancamento_id),
+});
+if (current && current.documento_id !== payload.from_documento_id) {
+  throw new Error(
+    `Q14 violation: L ${payload.lancamento_id} is currently in D ${current.documento_id}, ` +
+    `but move event says from D ${payload.from_documento_id}`
+  );
+}
+```
+**Alternativa (mais barata):** `CHECK (from_documento_id IS NOT NULL)` na migration + validação de `current_location` no app para impedir double-MOVE.
+
+**No Drizzle:**
+```ts
+criRelations: {
+  documento: many('documento', { relationName: 'documento_cri' })
+},
+// table definitions:
+// documento.cri_id: integer('cri_id').references(() => cri.id, { onDelete: 'restrict' })
+```
+
+### FTS5 — sync via triggers
+
+SQLite/D1 suporta FTS5 oficial. Para cada tabela com campos full-text, criar:
+1. Tabela virtual `*_fts` (FTS5 content table)
+2. Triggers `INSERT/UPDATE/DELETE` para manter `*_fts` em sync com a tabela base
+
+```sql
+-- Pessoa FTS
+CREATE VIRTUAL TABLE pessoa_fts USING fts5(
+  nome,
+  content='pessoa',
+  content_rowid='id'
+);
+
+CREATE TRIGGER pessoa_ai AFTER INSERT ON pessoa BEGIN
+  INSERT INTO pessoa_fts(rowid, nome) VALUES (new.id, new.nome);
+END;
+CREATE TRIGGER pessoa_ad AFTER DELETE ON pessoa BEGIN
+  INSERT INTO pessoa_fts(pessoa_fts, rowid, nome) VALUES('delete', old.id, old.nome);
+END;
+CREATE TRIGGER pessoa_au AFTER UPDATE ON pessoa BEGIN
+  INSERT INTO pessoa_fts(pessoa_fts, rowid, nome) VALUES('delete', old.id, old.nome);
+  INSERT INTO pessoa_fts(rowid, nome) VALUES (new.id, new.nome);
+END;
+
+-- Busca
+SELECT p.* FROM pessoa p
+JOIN pessoa_fts fts ON fts.rowid = p.id
+WHERE pessoa_fts MATCH 'joao silva*'
+  AND p.deleted_at IS NULL
+ORDER BY rank;
+```
+
+**Drizzle:** a tabela virtual FTS5 e os triggers vão via `sql.raw` na migration (Drizzle não tem DSL nativo pra FTS5). Helper: `scripts/db/fts5-helper.ts` (a criar em T-101) que gera SQL parametrizado pelo schema.
+
+**Aplicar a:**
+- `pessoa.nome` (Q4=A, sem criptografia)
+- `documento.outorgante_nome`, `outorgado_nome`, `endereco`
+- `cri.nome`
+- `lancamento.descricao`, `observacoes`
+- `anotacao_versao.texto`
+
+**Soft-delete + FTS5:** triggers usam `AFTER` (não `BEFORE`), então soft-delete (UPDATE `deleted_at`) **NÃO** remove do FTS5. A query de busca precisa filtrar `WHERE p.deleted_at IS NULL` (já mostrado acima). Trade-off: linhas soft-deletadas continuam no índice FTS, mas a query filtra. **Tamanho do índice cresce** com soft-deletes → rotina de vacuum (T-101).
+
+### Partial UNIQUE indexes
+
+`CREATE UNIQUE INDEX ... WHERE deleted_at IS NULL` em junctions. Aplicar em T-101 via Drizzle `sql.raw`:
+
+```sql
+-- Q13: 1 row por (I, D) ativo
+CREATE UNIQUE INDEX uq_imovel_documento_pair
+  ON imovel_documento(imovel_id, documento_id)
+  WHERE deleted_at IS NULL;
+
+-- Q15=🅳️: no máximo 1 D atual por Imóvel
+CREATE UNIQUE INDEX uq_imovel_documento_atual
+  ON imovel_documento(imovel_id)
+  WHERE is_documento_atual = 1 AND deleted_at IS NULL;
+
+-- T1+D1: UNIQUE no cri por CNS ativo
+CREATE UNIQUE INDEX uq_cri_cns
+  ON cri(cns_codigo)
+  WHERE cns_codigo IS NOT NULL AND deleted_at IS NULL;
+
+-- Q3: 1 OrigemFimCadeia por origem
+CREATE UNIQUE INDEX uq_origem_fim_cadeia_origem
+  ON origem_fim_cadeia(origem_id)
+  WHERE origem_id IS NOT NULL;
+```
+
+Drizzle não tem DSL pra `WHERE` em `uniqueIndex` ainda (issue #2456); workaround: `sql.raw` no migration ou Drizzle `index().where()`. Verificar na implementação T-101 qual a melhor forma.
+
+### Datas parciais (cartório tem data incompleta)
+
+Cartórios frequentemente registram data incompleta ("15/06/1950" sem hora, ou "junho/1950" sem dia). Schema v2 aceita esses formatos como `TEXT`:
+
+| Formato cartório | Como gravar | Validação |
+|---|---|---|
+| `'1950-06-15'` | ISO8601 date completo | `regex /^\d{4}-\d{2}-\d{2}$/` |
+| `'1950-06'` | ISO8601 year-month (parcial) | `regex /^\d{4}-\d{2}$/` (UI mostra "junho/1950") |
+| `'1950'` | Só ano (parcial) | `regex /^\d{4}$/` (UI mostra "1950") |
+| `'1950-06-15T14:30:00Z'` | ISO8601 datetime UTC | `regex /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/` |
+
+**Validação:** no app layer (Zod ou similar). DB aceita qualquer `TEXT` (não vale a pena CHECK constraint regex em SQLite — performance ruim, e regex no SQLite tem sintaxe limitada).
+
+**Sort:** SQLite ordena `TEXT` lexicograficamente, que **coincide** com ordenação cronológica para ISO8601. `"1950-06"` < `"1950-06-15"` < `"1950-07-01"`. Sem conversão pra DATE/JULIAN.
+
+**Comparações entre formatos:** `"1950-06-15" > "1950-06"` é correto. `"1950-06" = "1950-06"` é correto. Mas `"1950-06-15" = "1950-06-15T00:00:00Z"` é **FALSO** (string diferente). UI normaliza pra comparação (ex: trim do T-... quando ambos são pure-date).
+
+### CHECK constraints
+
+Aplicar via migration Drizzle em todos os enums:
+
+- `cri.tipo_cartorio` → `CHECK (tipo_cartorio IN ('CRI','NOTAS','CIVIL','TRANSMISSAO','OUTRO'))`
+- `lancamento_tipo.tipo` → `CHECK (tipo IN ('inicio_matricula','registro','averbacao'))`
+- `documento.tipo` → `CHECK (tipo IN ('matricula','transcricao'))`
+- `origem.tipo` → `CHECK (tipo IN ('matricula','transcricao','fim_cadeia'))`
+- `lancamento_pessoa.papel` → `CHECK (papel IN ('transmitente','adquirente','outorgante','outorgado','anuente','testemunha'))`
+- `audit_log.action` → `CHECK (action IN ('CREATE','EDIT','SOFT_DELETE','RESTORE','MOVE','ANNOTATE','EXPORT'))`
+- `imovel.arquivado` → `CHECK (arquivado IN (0,1))`
+- `imovel_documento.is_documento_atual` → `CHECK (is_documento_atual IN (0,1))`
+- `anotacao_versao.is_current` → `CHECK (is_current IN (0,1))`
+- `user.deleted_at IS NULL OR deleted_at GLOB '[0-9]*'` (data válida)
+
+> **Nota sobre Mermaid ERD (T4):** o .mmd (`erd-v2.mmd`) é **documentação visual**, NÃO schema canônico. Tipos `text` no Mermaid correspondem a `TEXT` no D1, mas a versão executável é a Drizzle migration (T-101). `UNIQUE_NOTE` é só annotation visual — partial UNIQUE indexes (`WHERE deleted_at IS NULL`), CHECK constraints, FTS5 sync triggers, e views (`v_lancamento_current_location`, `v_documento_orfao`) NÃO aparecem no .mmd; aplicar via migration Drizzle + SQL DDL. **Mermaid interpreta `--` e `|` em comentários como relações**, então CHECK constraints detalhados vão no .md, não no .mmd.
 
 ---
 
 ## Próximos passos
 
-1. **Luandro preenche a tabela de Decisões** (acima) com as opções escolhidas.
-2. As decisões são commitadas neste arquivo (em um PR de docs).
-3. O PR é mergeado na `v2`.
-4. T-001 do `docs/TASKS.md` é marcado como concluído.
-5. As tarefas T-100, T-101, T-200 etc. podem ser iniciadas.
+1. ✅ Decisões Q1–Q15 preenchidas (incluindo Q15=🅳️ decidida por @Hiure 2026-06-03).
+2. ✅ Crítica Codex 2026-06-03 round 2 processada: **4 decisões D1–D4** + **4 fixes técnicos T1–T4** aplicadas no ERD e na apêndice SQLite/D1.
+3. As decisões são commitadas neste arquivo (em um PR de docs).
+4. O PR é mergeado na `v2`.
+5. T-001 do `docs/TASKS.md` é marcado como concluído.
+6. T-100, T-101, T-104 podem ser iniciadas (não bloqueadas).
+7. T-105 pode ser iniciada (Q15=🅳️ destravou).
+
+---
+
+## Crítica Codex 2026-06-03 (gpt-5.5, high) — RESOLVIDA 2026-06-03
+
+> Ver `docs/db/CODEX_CRITIQUE_2026-06-03.md` para o relatório completo. **Verdict: NEEDS REWORK, medium severity.** Direção conceitual correta, blockers eram nível-implementação.
+>
+> **Status 2026-06-03 (round 2, todas resolvidas):**
+
+### Decisões aplicadas (Codex #1-#3, #6)
+
+| # | Achado | Decisão | Status |
+|---|---|---|---|
+| **D1** | `cri` precisa de UNIQUE ativo (cns_codigo) | `UNIQUE (cns_codigo) WHERE cns_codigo IS NOT NULL AND deleted_at IS NULL` (partial UNIQUE) | ✅ Aplicado |
+| **D2** | `origem` precisa de `numero_raw` | Adicionado `text numero_raw` à `origem` (verbatim) | ✅ Aplicado |
+| **D3** | Separar `user` (pesquisador) de `pessoa` (cartório) | `user` table criada; `lancamento_move_event.moved_by_id`, `audit_log.actor_id`, `anotacao_versao.created_by_id` migram de `pessoa_id` → `user_id`. `pessoa` continua domínio cartório. **`anotacao_versao.autor_original_id` corrigido para `user_id` no round 2 (F1, Codex bloqueante): Q9 fala de "pesquisador criando anotação", não cartório.** | ✅ Aplicado (corrigido F1) |
+| **D4** | Q15 recomendação: D | Q15=🅳️ decidido por @Hiure; default = desvincular, admin-only = apagar global, órfão = view `v_documento_orfao` | ✅ Aplicado |
+
+### Fixes técnicos aplicados (Codex #4, #5, #7, #8)
+
+| # | Achado | Fix | Status |
+|---|---|---|---|
+| **T1** | Faltam partial UNIQUE constraints em `imovel_documento` | `UNIQUE (imovel_id, documento_id) WHERE deleted_at IS NULL` + `UNIQUE (imovel_id) WHERE is_documento_atual=1 AND deleted_at IS NULL` (Q15=🅳️: garante no máximo 1 doc atual por Imóvel) | ✅ Documentado no .mmd, Drizzle vai aplicar |
+| **T2** | Q14 append-only MOVE precisa de SQL view determinística | `v_lancamento_current_location` (coroutine via `lancamento_move_event ORDER BY moved_at, id DESC LIMIT 1`); documentado em Q14 | ✅ Documentado em Q14 + view SQL inline |
+| **T3** | Apêndice SQLite/D1 incompleto | Expandido com: FTS5 sync (triggers INSERT/UPDATE/DELETE), FK actions explícitas (RESTRICT/SET NULL/CASCADE), sem `NOW()` PG (UTC ISO8601 no app), datas parciais do cartório (`text` com validação leve de formato) | ✅ Apêndice expandido |
+| **T4** | Mermaid `UNIQUE_NOTE` é só visual, não enforce | Nota explícita no topo do .mmd: "Mermaid NÃO é schema. UNIQUE_NOTE é só documentação visual. Drizzle migration é canônica" | ✅ Nota no topo do .mmd |
+
+### Tabelas adicionais (Codex #5 - estado derivado)
+
+| View | Propósito | Substitui |
+|---|---|---|
+| `v_lancamento_current_location` | "Onde o L está AGORA?" (Q14) | Regra UI-only frágil que geraria lançamentos fantasma |
+| `v_documento_orfao` | "Quais D's não estão em nenhuma chain ativa?" (Q15=🅳️) | Flag `is_orfao` desatualizaria em reatribuição |
+
+Ambas views são D1-compatíveis (CREATE VIEW suportado em SQLite). Implementação em Drizzle migration T-101.
+
+---
+
+## Crítica Codex 2026-06-03 Round 2 (gpt-5.5, xhigh) — RESOLVIDA 2026-06-03
+
+> Ver `docs/db/CODEX_CRITIQUE_2026-06-03_ROUND2.md` para o relatório completo. **Verdict: NEEDS-MINOR-FIXES.** 2 BLOCKERS (F1, F2), 1 NICE-TO-HAVE (F3), 4 inconsistências textuais.
+
+### Achados round 2 resolvidos
+
+| # | Achado | Fix | Status |
+|---|---|---|---|
+| **F1** | `anotacao_versao.autor_original_id` apontava para `pessoa` (cartório), contradizendo Q9 (researcher attribution) | Mudado para `user_id` (pesquisador); visual edge `pessoa ||--o{ imovel_documento : "anotou"` corrigida para `user \|\|--o{ anotacao_versao : "autor_original"` (a edge original estava geometricamente errada — FK mora em `anotacao_versao`, não em `imovel_documento`) | ✅ Aplicado |
+| **F2** | `anotacao_versao` é soft-deletable (legend) mas faltava `deleted_at` | Adicionado `text deleted_at`; documentada a diferença: `deleted_at` = apaga anotação INTEIRA (todas versões); `is_current=0` = marca versão como não-atual mas mantém no histórico | ✅ Aplicado |
+| **F3** | T3 FK actions incompleta + faltava `lancamento_tipo \|\|--o{ lancamento` visual | 6 FKs adicionadas (`lancamento.tipo_id`, `anotacao_versao.autor_original_id`/`created_by_id`/`operation_id`, `lancamento_move_event.moved_by_id`/`audit_log_id`, `origem.documento_id`, `tis.terra_referencia_id`); edge `lancamento_tipo \|\|--o{ lancamento : "classifica"` adicionada | ✅ Aplicado |
+| **F4** | Q2 seção ainda recomendava C; tabela de Decisões diz B | Seção de Q2 atualizada para refletir a decisão final (B) com justificativa do contexto v2 (pesquisadores de grilagem) | ✅ Aplicado |
+| **F5** | Q1 intro dizia "6 perguntas (Q1 a Q6)" | Atualizado para "15 perguntas (Q1–Q15, mais Q11b)" | ✅ Aplicado |
+| **F6** | Q11b "schema final" snippet ainda mostrava `documento.imovel_id` e `documento.is_documento_atual` (removidos em Q13) | Snippet atualizado com comentários `// (Q13) REMOVIDO em v2` | ✅ Aplicado |
+| **F7** | Q14 invariante write-time faltando | Documentada invariante (validar `from_documento_id` = `v_lancamento_current_location` antes de INSERT) com snippet TS | ✅ Documentado |
 
 **Perguntas ou discordâncias?** Abra um issue ou comente direto neste PR.

--- a/docs/db/SCHEMA_DECISOES_PENDENTES.md
+++ b/docs/db/SCHEMA_DECISOES_PENDENTES.md
@@ -821,6 +821,8 @@ WHERE d.deleted_at IS NULL;
 
 **D1/SQLite support:** `CREATE VIEW` totalmente suportado. Custo: index em `lancamento_move_event(lancamento_id, moved_at DESC, id DESC)` para performance (Drizzle adiciona via `CREATE INDEX` na migration T-101).
 
+**Edge case documentado para T-101 (round 3, Opus 4.8 flag):** o `INNER JOIN documento d ... WHERE d.deleted_at IS NULL` significa que, se o documento atual de um L for **soft-deletado** (D entra em estado "removal pending" via Q15=🅳️), o L **desaparece completamente da view** — não há fallback para o D anterior. **Isso é intencional**, alinhado com Q15=🅳️ (soft-delete de D é admin-only, intencional, e o L fica "preso" até (a) o D ser restaurado por admin, ou (b) um novo MOVE ser executado pelo pesquisador apontando o L para outro D). T-101 NÃO deve implementar fallback para `lancamento_move_event.to_documento_id` mais antigo que ainda não foi soft-deletado — isso violaria Q15=🅳️ (esconderia que D foi removido e o L "pularia" para o histórico, criando inconsistência forense). A UI deve detectar "L sumiu da chain de D" e mostrar estado explícito "D em remoção — veja admin".
+
 **Por que não coluna `current_documento_id` em `lancamento`?**
 - Quebraria Q14=B (append-only) — coluna seria mutada em cada MOVE.
 - Q8=🅰️ (restore simétrico) não conseguiria desfazer via SQL: precisaria salvar estado anterior.
@@ -908,7 +910,7 @@ Usuário clica "Apagar" em Documento D
 
 ## Decisões
 
-> ✅ **Seção preenchida em 2026-06-02/03** durante sessão de grupo com Luandro (decisor) e Hiure (implementador). Q15 ainda em aberto. As decisões destravam T-001 e liberam o início de T-100 (re-desenhar o ERD aplicando Q1–Q14) e T-101 (schema Drizzle).
+> ✅ **Seção preenchida em 2026-06-02/03** durante sessão de grupo com Luandro (decisor) e Hiure (implementador). Q1–Q15 (mais Q11b) decididas, incluindo Q15=🅳️ decidida por @Hiure em 2026-06-03. As decisões destravam T-001 e liberam o início de T-100 (re-desenhar o ERD aplicando Q1–Q14) e T-101 (schema Drizzle).
 >
 > **Contexto crítico que ancorou várias decisões** (revelado por Hiure durante a sessão): o v2 é usado por um **grupo de pesquisadores investigando grilagem de terras**, não por cartório. Eles copiam dados do cartório pro sistema **exatamente como estão** (inclusive erros), porque **divergências entre certidões são indícios de grilagem**. Sistema = cópia fiel + camada de análise, NÃO uma base "limpa".
 
@@ -937,7 +939,7 @@ Usuário clica "Apagar" em Documento D
 
 - **Nova task T-104 — Controles de visualização da cadeia** (toggle de ramos, colapso de subárvore, filtros por classificação, layouts de export PDF/XLSX/PNG). **Bloqueada em T-100 e T-101.** Justificativa: cadeias com centenas de documentos inviabilizam a visualização sem esses controles; precisa ser uma feature de UI/UX própria, não uma escolha binária escondida dentro da Q6. Detalhes no TASKS.md.
 - **Sub-task do T-300 (legacy-fit)** — "Definir e descartar colunas PII do legado". Lista atual: `Pessoas.cpf`, `Pessoas.rg`, `Pessoas.data_nascimento`, `Pessoas.email`, `Pessoas.telefone`. Migrar do Postgres legado (que tem esses campos) pro Drizzle/D1 (que não terá) sem perda funcional.
-- **T-105 (Soft-delete workflow)** — implementação do delete UX (Q7a/B, Q12=🅳️), restore (Q8=🅰️), MOVE (Q14=🅱️), delete de Documento shared (Q15 — bloqueada até decisão). **Bloqueada em T-100/T-101 E na decisão de Q15.**
+- **T-105 (Soft-delete workflow)** — implementação do delete UX (Q7a/B, Q12=🅳️), restore (Q8=🅰️), MOVE (Q14=🅱️), delete de Documento shared (Q15=🅳️ já decidida). **Bloqueada apenas em T-100/T-101.** Q15 já está resolvida (ver decisão acima).
 
 **Notas finais para implementadores (T-100/T-101):**
 - A tabela acima (linhas de Decisões) é a fonte de verdade. Use-a como referência canônica.

--- a/docs/db/SCHEMA_DECISOES_PENDENTES.md
+++ b/docs/db/SCHEMA_DECISOES_PENDENTES.md
@@ -794,17 +794,24 @@ Regra UI-only ("L aparece na chain de D' se existe move event mais recente com `
 ```sql
 CREATE VIEW v_lancamento_current_location AS
 SELECT
-  l.id AS lancamento_id,
-  COALESCE(
-    (SELECT me.to_documento_id
-     FROM lancamento_move_event me
-     WHERE me.lancamento_id = l.id
-     ORDER BY me.moved_at DESC, me.id DESC
-     LIMIT 1),
-    l.documento_id
-  ) AS current_documento_id
-FROM lancamento l
-WHERE l.deleted_at IS NULL;
+  inner_q.lancamento_id,
+  inner_q.current_documento_id
+FROM (
+  SELECT
+    l.id AS lancamento_id,
+    COALESCE(
+      (SELECT me.to_documento_id
+       FROM lancamento_move_event me
+       WHERE me.lancamento_id = l.id
+       ORDER BY me.moved_at DESC, me.id DESC
+       LIMIT 1),
+      l.documento_id
+    ) AS current_documento_id
+  FROM lancamento l
+  WHERE l.deleted_at IS NULL
+) inner_q
+INNER JOIN documento d ON d.id = inner_q.current_documento_id
+WHERE d.deleted_at IS NULL;
 ```
 
 **Como a UI consome:**
@@ -981,6 +988,7 @@ Toda FK precisa ter `onDelete` explícito. Defaults Drizzle = `NO ACTION` (= RES
 | `documento.cri_id` → `cri.id` | `RESTRICT` | Não pode apagar CRI com docs; admin tem hard-delete separado |
 | `imovel.cri_id` → `cri.id` | `RESTRICT` | Mesmo |
 | `origem.cri_id` → `cri.id` | `RESTRICT` | Mesmo |
+| `origem.lancamento_id` → `lancamento.id` | `RESTRICT` | Q3 (round 3): `origem` carrega evidência verbatim (`numero_raw`); CASCADE apagaria evidência junto com L. RESTRICT protege a cadeia forense. Hard-delete de L é admin-only e explícito. |
 | `lancamento.documento_id` → `documento.id` | `SET NULL` | Q7b=B: L preservado órfão se D sumir |
 | `lancamento.tipo_id` → `lancamento_tipo.id` | `RESTRICT` | Não pode apagar tipo em uso; criar novo + migrate L se necessário |
 | `lancamento_pessoa.lancamento_id` → `lancamento.id` | `CASCADE` | Junction de membership, segue o L |
@@ -1009,9 +1017,9 @@ Toda FK precisa ter `onDelete` explícito. Defaults Drizzle = `NO ACTION` (= RES
 const current = await db.query.v_lancamento_current_location.findFirst({
   where: eq(v_lancamento_current_location.lancamento_id, payload.lancamento_id),
 });
-if (current && current.documento_id !== payload.from_documento_id) {
+if (current && current.current_documento_id !== payload.from_documento_id) {
   throw new Error(
-    `Q14 violation: L ${payload.lancamento_id} is currently in D ${current.documento_id}, ` +
+    `Q14 violation: L ${payload.lancamento_id} is currently in D ${current.current_documento_id}, ` +
     `but move event says from D ${payload.from_documento_id}`
   );
 }
@@ -1120,7 +1128,7 @@ Cartórios frequentemente registram data incompleta ("15/06/1950" sem hora, ou "
 
 Aplicar via migration Drizzle em todos os enums:
 
-- `cri.tipo_cartorio` → `CHECK (tipo_cartorio IN ('CRI','NOTAS','CIVIL','TRANSMISSAO','OUTRO'))`
+- ~~`cri.tipo_cartorio` → `CHECK (tipo_cartorio IN ('CRI','NOTAS','CIVIL','TRANSMISSAO','OUTRO'))`~~ **REMOVIDO (round 3)**: a coluna `tipo_cartorio` não existe no ERD (`cri` tem só `nome`, `cns_codigo`, `cidade`, `uf`, `endereco`). Adicionar essa coluna é fora de escopo das decisões Q1-Q15 — `cri` é especificamente o cartório de registro de imóveis, não um cartório genérico.
 - `lancamento_tipo.tipo` → `CHECK (tipo IN ('inicio_matricula','registro','averbacao'))`
 - `documento.tipo` → `CHECK (tipo IN ('matricula','transcricao'))`
 - `origem.tipo` → `CHECK (tipo IN ('matricula','transcricao','fim_cadeia'))`
@@ -1167,7 +1175,7 @@ Aplicar via migration Drizzle em todos os enums:
 | # | Achado | Fix | Status |
 |---|---|---|---|
 | **T1** | Faltam partial UNIQUE constraints em `imovel_documento` | `UNIQUE (imovel_id, documento_id) WHERE deleted_at IS NULL` + `UNIQUE (imovel_id) WHERE is_documento_atual=1 AND deleted_at IS NULL` (Q15=🅳️: garante no máximo 1 doc atual por Imóvel) | ✅ Documentado no .mmd, Drizzle vai aplicar |
-| **T2** | Q14 append-only MOVE precisa de SQL view determinística | `v_lancamento_current_location` (coroutine via `lancamento_move_event ORDER BY moved_at, id DESC LIMIT 1`); documentado em Q14 | ✅ Documentado em Q14 + view SQL inline |
+| **T2** | Q14 append-only MOVE precisa de SQL view determinística | `v_lancamento_current_location` (coroutine via `lancamento_move_event ORDER BY moved_at DESC, id DESC LIMIT 1`); documentado em Q14 | ✅ Documentado em Q14 + view SQL inline |
 | **T3** | Apêndice SQLite/D1 incompleto | Expandido com: FTS5 sync (triggers INSERT/UPDATE/DELETE), FK actions explícitas (RESTRICT/SET NULL/CASCADE), sem `NOW()` PG (UTC ISO8601 no app), datas parciais do cartório (`text` com validação leve de formato) | ✅ Apêndice expandido |
 | **T4** | Mermaid `UNIQUE_NOTE` é só visual, não enforce | Nota explícita no topo do .mmd: "Mermaid NÃO é schema. UNIQUE_NOTE é só documentação visual. Drizzle migration é canônica" | ✅ Nota no topo do .mmd |
 
@@ -1197,5 +1205,27 @@ Ambas views são D1-compatíveis (CREATE VIEW suportado em SQLite). Implementaç
 | **F5** | Q1 intro dizia "6 perguntas (Q1 a Q6)" | Atualizado para "15 perguntas (Q1–Q15, mais Q11b)" | ✅ Aplicado |
 | **F6** | Q11b "schema final" snippet ainda mostrava `documento.imovel_id` e `documento.is_documento_atual` (removidos em Q13) | Snippet atualizado com comentários `// (Q13) REMOVIDO em v2` | ✅ Aplicado |
 | **F7** | Q14 invariante write-time faltando | Documentada invariante (validar `from_documento_id` = `v_lancamento_current_location` antes de INSERT) com snippet TS | ✅ Documentado |
+
+---
+
+## Crítica Codex 2026-06-03 Round 3 (gpt-5.5, xhigh) — Triage + fixes aplicados 2026-06-03
+
+> Triagem dos 8 inline review threads abertos (Codex 3 + Greptile 5) contra a PR #24. **Verdict inicial do triage: ship-blocked (1 BLOCKER + 5 MUST-FIX + 1 NICE-TO-HAVE, 0 DISAGREE).** Todos os 7 fixes únicos aplicados.
+
+| # | Issue | Severity | Fix aplicado | Status |
+|---|---|---|---|---|
+| **R3-1** | Q14 TS invariant lia o nome de campo errado da view (campo `documento_id` no read, view expõe `current_documento_id`) — invariante silenciosamente no-op | MUST-FIX | Linha 1012 (`if`) + linha 1014 (throw message): campo agora é `current.current_documento_id` | ✅ Aplicado |
+| **R3-2** | `SCHEMA_CONSOLIDATED.md` é stale (ainda referencia v1) mas a legend e decisões o marcam como canonical | **BLOCKER** | Aviso de SUPERSEDED no topo de `SCHEMA_CONSOLIDATED.md`; legend atualizada para indicar SUPERSEDED e apontar para `SCHEMA_DECISOES_PENDENTES.md` + `erd-v2.mmd` | ✅ Aplicado |
+| **R3-3** | F1 voltou na legend: `anotacao_versao.autor_original_id` descrito como `pessoa` (mas ERD e decisions já apontam para `user`) | MUST-FIX | Legend linha 78 + 99: `pessoa` → `user`; nota explícita do round 2 fix | ✅ Aplicado |
+| **R3-4** | `v_lancamento_current_location` filtra `lancamento.deleted_at` mas não filtra `documento.deleted_at` no `to_documento_id` resolvido — pode mostrar doc soft-deletado como current location | MUST-FIX | View reescrita com inner query + `INNER JOIN documento d ON d.id = inner_q.current_documento_id WHERE d.deleted_at IS NULL` | ✅ Aplicado |
+| **R3-5** | `cri.tipo_cartorio` CHECK no apêndice mas a coluna não existe no ERD | MUST-FIX | Linha riscada com justificativa (round 3): coluna fora de escopo Q1-Q15; `cri` é especificamente registro de imóveis | ✅ Aplicado |
+| **R3-6** | FK action de `origem.lancamento_id` ausente da tabela — `origem` carrega evidência verbatim, CASCADE apagaria forense | MUST-FIX | Adicionada `origem.lancamento_id → lancamento.id | RESTRICT` (proteger cadeia forense) | ✅ Aplicado |
+| **R3-7** | T2 fix summary `ORDER BY moved_at, id DESC` ambíguo (sem DESC explícito no `moved_at`) | NICE-TO-HAVE | Adicionado `DESC` no `moved_at` para consistência com SQL inline | ✅ Aplicado |
+
+**R3-8** (Codex #2 dup) e **R3-4 dup** (Greptile P1 duplicata de R3-1) — não contados separadamente.
+
+**Verdict final após fixes (pendente round 3 review):** Aguardando aprovação do Codex round 3 para confirmar APROVA.
+
+---
 
 **Perguntas ou discordâncias?** Abra um issue ou comente direto neste PR.

--- a/docs/db/erd-v2-legend.md
+++ b/docs/db/erd-v2-legend.md
@@ -1,61 +1,109 @@
-# Legenda - Diagrama de Entidades (ERD)
+# Legenda - Diagrama de Entidades (ERD) v2
 
 Este diagrama mostra **tabelas** (caixas) e **relacionamentos** (linhas) entre elas. A ideia e que qualquer pessoa consiga entender o que cada linha significa.
 
+> **Decisoes de design** (Q1-Q15, Q11b, D1-D4, T1-T4) que ancoram este ERD: `docs/db/SCHEMA_DECISOES_PENDENTES.md`. **Schema canonico** (colunas, constraints, tipos SQLite/D1): `docs/db/SCHEMA_CONSOLIDATED.md`. **Critica completa do Codex gpt-5.5 (high)**: `docs/db/CODEX_CRITIQUE_2026-06-03.md`.
+>
+> **T4 — Mermaid NAO e schema.** O `.mmd` e documentacao visual. UNIQUE_NOTE, comentarios inline, e tipos no Mermaid nao sao enforcem em SQL. A versao canonica e a Drizzle migration (T-101) com partial UNIQUE indexes, CHECK constraints, FTS5 sync triggers, e views.
+
 ## 1) O que e cada caixa (tabela)
+
 - Cada caixa representa uma **tabela** do banco de dados.
-- Dentro da caixa estao os **campos** (colunas) com seu tipo (ex: `string`, `int`, `date`).
+- Dentro da caixa estao os **campos** (colunas) com seu tipo (`int`, `text`, `integer`).
 - `PK` = **Primary Key** (identificador unico da linha).
 - `FK` = **Foreign Key** (campo que aponta para outra tabela).
 
+### Tipos no ERD (convencao SQLite/D1 — ver Apêndice em SCHEMA_DECISOES_PENDENTES.md)
+
+| Notacao no ERD | Tipo real (D1/SQLite) |
+|---|---|
+| `int` | `INTEGER` |
+| `text` | `TEXT` |
+| `integer` com `0/1` no comment | `INTEGER` + `CHECK (col IN (0,1))` (boolean) |
+| `date` / `data` | `TEXT` ISO8601 (`'2026-06-03'`) |
+| `datetime` | `TEXT` ISO8601 com hora (`'2026-06-03T14:30:00Z'`) |
+| `decimal valor_transacao` | `INTEGER` em **centavos** (evita rounding errors) |
+| `decimal area` | `INTEGER` em **centiares** (1 are = 100 m²) |
+
 ## 2) Como ler os relacionamentos
+
 O formato e do tipo: `A ||--o{ B : rotulo`
+
 - **A** e a tabela de origem
 - **B** e a tabela relacionada
 - **rotulo** explica o sentido da relacao em linguagem humana
 
 ### Cardinalidade (quantidade de registros)
+
 - `||` = exatamente 1
 - `o|` = 0 ou 1 (opcional)
 - `o{` = 0 ou muitos
 - `|{` = 1 ou muitos
 
-### Exemplos simples
-- `cri ||--o{ documento : emite`
-  - Um **CRI** pode emitir **varios documentos**.
-  - Um documento pertence a **um** CRI.
+### Exemplos simples (Q11b aplicado)
 
-- `lancamento ||--o{ origem : possui`
+- `cri ||--o{ documento : emite (Q11b=C, FK direto, sem junction)`
+  - Um **CRI** pode emitir **varios documentos**.
+  - Um documento pertence a **um** CRI (FK direto, sem tabela intermediaria).
+  - **Constraint:** `UNIQUE (cri_id, tipo, numero)` — mesma matricula em CRIs diferentes = documentos diferentes.
+
+- `imovel ||--o{ imovel_documento : pertence (Q13=B, N:N)`
+  - Um **imovel** tem **varios** documentos (via junction).
+  - Um **documento** pode estar em **varios** imoveis (compartilhamento de cadeia entre grileiros).
+  - `is_documento_atual` e **per-par** (Imovel, Documento), nao global.
+
+- `lancamento ||--o{ origem : possui (Q3=B)`
   - Um **lancamento** pode ter **varias origens**.
   - Cada origem pertence a **um** lancamento.
+  - Cada origem pode ter (zero ou um) `origem_fim_cadeia` independente (classificacao por origem).
 
-- `origem ||--o| origem_fim_cadeia : fim_cadeia`
-  - Uma **origem** pode ter **zero ou um** fim de cadeia.
+- `origem o|--o{ origem_fim_cadeia : "?"` (na verdade e 1:1)
+  - Ver: `origem ||--o| origem_fim_cadeia : fim_cadeia` — uma origem pode ter zero ou um registro de fim de cadeia.
 
 ## 3) Significado dos rotulos (texto nas linhas)
-- **emite**: CRI registra um documento.
-- **registra**: CRI esta associado a um imovel.
-- **possui**: entidade tem varias ligacoes (ex: imovel -> documento).
-- **proprietario**: pessoa relacionada ao imovel como proprietario.
-- **gera**: documento que gera lancamentos.
-- **classifica**: tipo que define regras do lancamento.
-- **envolve / participa**: ligacao entre lancamento e pessoa.
-- **referencia**: origem aponta para um CRI (opcional).
-- **origem_doc**: origem aponta para um documento (opcional).
-- **transmissao**: cartorio_transmissao usado na transmissao do lancamento.
-- **vincula (TI)**: imovel associado a uma TI.
-- **referencia (TI)**: TI aponta para a tabela de referencia oficial.
+
+- **emite (Q11b=C)**: CRI registra um documento. FK direto, sem junction. UNIQUE (cri_id, tipo, numero).
+- **registra (Q11b=B, fixo)**: CRI esta associado a um imovel. **Fixo, sem historico no v1** (pesquisadores trabalham com documentos ja consolidados).
+- **pertence (Q13=B, N:N)**: imovel_documento (junction) — Documento e **igualmente pertencente** a todos os imoveis que o citam.
+- **proprietario**: pessoa relacionada ao imovel como proprietario. Pode ser NULL apos anonimizacao LGPD.
+- **gera**: documento gera lancamentos.
+- **classifica**: tipo que define regras (UI flags) do lancamento.
+- **envolve / participa (Q2=B)**: ligacao entre lancamento e pessoa via `lancamento_pessoa`. `nome_verbatim` preserva evidencia mesmo se `pessoa_id` vira NULL (LGPD).
+- **referencia (cri_origem, Q11b=A)**: origem aponta para um CRI. **Este campo ja e o "cri_origem_id" do Lancamento** (NÃO adicionar coluna separada).
+- **origem_doc**: origem aponta para um documento (opcional, NULL se tipo=fim_cadeia).
+- **movido (Q14=B, append-only)**: lancamento_move_event registra MOVE cross-chain. Lancamento NAO e mutado.
+- **from_doc / to_doc (Q14=B)**: D origem e D destino do MOVE.
+- **moved_by (D3)**: `user` (pesquisador) que executou o MOVE. NAO `pessoa` (que e do dominio cartorio).
+- **actor (D3)**: `user` (pesquisador) que executou a acao registrada no `audit_log`. NAO `pessoa`.
+- **created_by (D3)**: `user` editor da `anotacao_versao`. DIFERENTE de `autor_original_id`, que permanece como `pessoa` (criador original, imutavel por Q9=C).
+- **anotado_em (Q9=C)**: anotacao_versao registra anotacoes analiticas do pesquisador. Trilha de versoes + provenance de criacao.
+- **anotou (Q9=C)**: autor_original_id da anotacao. **NUNCA muda** (mesmo se outrem editar a anotacao depois).
+- **vincula_TI**: imovel associado a uma Terra Indigena (N:N via tis_imovel).
+- **referencia (TI)**: TI aponta para a tabela de referencia oficial (terra_indigena_referencia).
 
 ## 4) Campos importantes explicados em linguagem simples
-- **documento.is_documento_atual**: marca o documento vigente do imovel (apenas 1 por imovel).
-- **cartorio_transmissao_id**: cartorio manual usado na transmissao.
+
+- **documento.numero**: normalizado, so digitos. Mesmo formato `M` ou `T` + numero.
+- **documento.numero_raw**: valor original do cartorio (com pontos, tracos, etc). **NUNCA usado em busca** (e so para referencia).
+- **documento.outorgante_nome / outorgado_nome / endereco**: busca fuzzy FTS5 (Q10=A — sem `_raw` + `_normalized`; variacao real entre certidões e preservada).
+- **imovel_documento.is_documento_atual (Q13=B)**: per-par (Imovel, Documento). "Documento X e o atual pro imovel Y" — pode ser FALSE pra outros imoveis.
+- **imovel.cri_id (Q11b=B)**: FIXO, sem historico no v1. Se comarca mudar na historia do imovel, criar `imovel_cri_historico` depois.
 - **origem.tipo**: `matricula`, `transcricao` ou `fim_cadeia`.
 - **origem.documento_id**: documento de origem (opcional, quando tipo != `fim_cadeia`).
-- **origem.indice**: ordem das origens dentro de um lancamento (0, 1, 2...).
+- **origem.indice**: ordem das origens dentro de um lancamento (0, 1, 2...). UNIQUE (lancamento_id, indice), contiguo (enforce via app).
+- **origem.cri_id (Q11b=A)**: CRI de origem. **NÃO** duplicar em `lancamento.cri_origem_id`.
 - **origem_fim_cadeia.sigla_patrimonio_publico**: sigla do orgao (ex: INCRA, SPU) quando aplicavel.
-- **lancamento.numero_lancamento**: numero informado pelo usuario (nao e derivado); usado para compor a sigla exibida (ex: `AV5 M123`).
+- **lancamento.numero_lancamento**: numero informado pelo usuario (nao e derivado); usado para compor a sigla exibida (ex: `AV5 M123`). UNIQUE (documento_id, numero_lancamento).
+- **lancamento.cartorio_transmissao_nome (Q11b)**: FREE-FORM TEXT, sem FK. Tabelionato de notas (compra e venda, etc) — pode ser qualquer um, nao precisa ser normalizado.
+- **lancamento_move_event (Q14=B)**: append-only. Registra MOVE cross-chain. Lancamento NAO e mutado. `from_documento_id` e `to_documento_id` sao os D origem e destino.
+- **anotacao_versao.autor_original_id (Q9=C)**: pessoa que criou a anotacao. **IMUTAVEL** (so o editor muda entre versoes, nao o autor).
+- **anotacao_versao.current_marker (Q9=C)**: marca a versao atual da anotacao. `partial UNIQUE (imovel_documento_id) WHERE is_current=1`.
+- **deleted_at (Q2=B)**: presente em imovel, documento, lancamento, lancamento_pessoa, imovel_documento, pessoa, anotacao_versao, cri. Soft-delete e a estrategia padrao. Hard-delete admin-only.
 
 ## 5) Observacoes sobre obrigatoriedade
+
 - Um campo marcado como `FK` pode ser **obrigatorio ou opcional** dependendo da regra de negocio.
 - A obrigatoriedade especifica esta definida no documento `docs/db/SCHEMA_CONSOLIDATED.md`.
-- No SQLite, `bool` representa `INTEGER` (0/1).
+- **UNIQUE constraints** vao via migration Drizzle (Mermaid nao suporta `UNIQUE` em declaracao de campo).
+- **CHECK constraints** vao via migration Drizzle (Mermaid interpreta `--` e `|` em comentarios como relacoes — usar `text` com descricao em vez de constraint syntax).
+- **Cascade conservador (Q7b=B)**: soft-delete de Imovel toca APENAS `imovel_documento` (junctions). Lancamentos, lancamento_pessoa, Documentos, Pessoas, CRIs **NAO sao tocados** (evidencia preservada).

--- a/docs/db/erd-v2-legend.md
+++ b/docs/db/erd-v2-legend.md
@@ -97,7 +97,7 @@ O formato e do tipo: `A ||--o{ B : rotulo`
 - **lancamento.cartorio_transmissao_nome (Q11b)**: FREE-FORM TEXT, sem FK. Tabelionato de notas (compra e venda, etc) — pode ser qualquer um, nao precisa ser normalizado.
 - **lancamento_move_event (Q14=B)**: append-only. Registra MOVE cross-chain. Lancamento NAO e mutado. `from_documento_id` e `to_documento_id` sao os D origem e destino.
 - **anotacao_versao.autor_original_id (Q9=C, F1)**: `user` (pesquisador) que criou a anotação. **IMUTÁVEL** (só o editor `created_by_id` muda entre versões, não o autor). **Round 2 corrigiu: era `pessoa` na v1/legado; foi movido para `user` porque Q9=C fala de pesquisador criando anotação, não de cartório.**
-- **anotacao_versao.current_marker (Q9=C)**: marca a versao atual da anotacao. `partial UNIQUE (imovel_documento_id) WHERE is_current=1`.
+- **anotacao_versao.is_current (Q9=C)**: marca a versão atual da anotação (`integer`, 0/1, com `partial UNIQUE (imovel_documento_id) WHERE is_current=1` garantindo no máximo 1 versão "atual" por junction). `is_current=0` = versão antiga, mantida no histórico (F2). `is_current=1` (junto com `deleted_at IS NULL`) = versão visível na UI. (Não existe coluna `current_marker` — a flag é `is_current`.)
 - **deleted_at (Q2=B)**: presente em imovel, documento, lancamento, lancamento_pessoa, imovel_documento, pessoa, anotacao_versao, cri. Soft-delete e a estrategia padrao. Hard-delete admin-only.
 
 ## 5) Observacoes sobre obrigatoriedade

--- a/docs/db/erd-v2-legend.md
+++ b/docs/db/erd-v2-legend.md
@@ -2,7 +2,7 @@
 
 Este diagrama mostra **tabelas** (caixas) e **relacionamentos** (linhas) entre elas. A ideia e que qualquer pessoa consiga entender o que cada linha significa.
 
-> **Decisoes de design** (Q1-Q15, Q11b, D1-D4, T1-T4) que ancoram este ERD: `docs/db/SCHEMA_DECISOES_PENDENTES.md`. **Schema canonico** (colunas, constraints, tipos SQLite/D1): `docs/db/SCHEMA_CONSOLIDATED.md`. **Critica completa do Codex gpt-5.5 (high)**: `docs/db/CODEX_CRITIQUE_2026-06-03.md`.
+> **Decisoes de design** (Q1-Q15, Q11b, D1-D4, T1-T4) que ancoram este ERD: `docs/db/SCHEMA_DECISOES_PENDENTES.md`. **Schema canonico** (colunas, constraints, tipos SQLite/D1): **`docs/db/SCHEMA_CONSOLIDATED.md` ESTÁ SUPERSEDED — ver aviso no topo desse arquivo; usar `docs/db/SCHEMA_DECISOES_PENDENTES.md` + `erd-v2.mmd` como referência canônica até a migration T-101 ser aplicada**. **Critica completa do Codex gpt-5.5 (xhigh)**: `docs/db/CODEX_CRITIQUE_2026-06-03.md` (round 1) e `docs/db/CODEX_CRITIQUE_2026-06-03_ROUND2.md` (round 2) e triage round 3 em "Próximos passos" do decisions doc.
 >
 > **T4 — Mermaid NAO e schema.** O `.mmd` e documentacao visual. UNIQUE_NOTE, comentarios inline, e tipos no Mermaid nao sao enforcem em SQL. A versao canonica e a Drizzle migration (T-101) com partial UNIQUE indexes, CHECK constraints, FTS5 sync triggers, e views.
 
@@ -75,7 +75,7 @@ O formato e do tipo: `A ||--o{ B : rotulo`
 - **from_doc / to_doc (Q14=B)**: D origem e D destino do MOVE.
 - **moved_by (D3)**: `user` (pesquisador) que executou o MOVE. NAO `pessoa` (que e do dominio cartorio).
 - **actor (D3)**: `user` (pesquisador) que executou a acao registrada no `audit_log`. NAO `pessoa`.
-- **created_by (D3)**: `user` editor da `anotacao_versao`. DIFERENTE de `autor_original_id`, que permanece como `pessoa` (criador original, imutavel por Q9=C).
+- **created_by (D3)**: `user` editor da `anotacao_versao`. DIFERENTE de `autor_original_id`, que também aponta para `user` (F1: era `pessoa`, corrigido no round 2 — Q9=C fala de pesquisador, não cartório). `created_by` é o editor; `autor_original` é o criador imutável.
 - **anotado_em (Q9=C)**: anotacao_versao registra anotacoes analiticas do pesquisador. Trilha de versoes + provenance de criacao.
 - **anotou (Q9=C)**: autor_original_id da anotacao. **NUNCA muda** (mesmo se outrem editar a anotacao depois).
 - **vincula_TI**: imovel associado a uma Terra Indigena (N:N via tis_imovel).
@@ -96,14 +96,14 @@ O formato e do tipo: `A ||--o{ B : rotulo`
 - **lancamento.numero_lancamento**: numero informado pelo usuario (nao e derivado); usado para compor a sigla exibida (ex: `AV5 M123`). UNIQUE (documento_id, numero_lancamento).
 - **lancamento.cartorio_transmissao_nome (Q11b)**: FREE-FORM TEXT, sem FK. Tabelionato de notas (compra e venda, etc) — pode ser qualquer um, nao precisa ser normalizado.
 - **lancamento_move_event (Q14=B)**: append-only. Registra MOVE cross-chain. Lancamento NAO e mutado. `from_documento_id` e `to_documento_id` sao os D origem e destino.
-- **anotacao_versao.autor_original_id (Q9=C)**: pessoa que criou a anotacao. **IMUTAVEL** (so o editor muda entre versoes, nao o autor).
+- **anotacao_versao.autor_original_id (Q9=C, F1)**: `user` (pesquisador) que criou a anotação. **IMUTÁVEL** (só o editor `created_by_id` muda entre versões, não o autor). **Round 2 corrigiu: era `pessoa` na v1/legado; foi movido para `user` porque Q9=C fala de pesquisador criando anotação, não de cartório.**
 - **anotacao_versao.current_marker (Q9=C)**: marca a versao atual da anotacao. `partial UNIQUE (imovel_documento_id) WHERE is_current=1`.
 - **deleted_at (Q2=B)**: presente em imovel, documento, lancamento, lancamento_pessoa, imovel_documento, pessoa, anotacao_versao, cri. Soft-delete e a estrategia padrao. Hard-delete admin-only.
 
 ## 5) Observacoes sobre obrigatoriedade
 
 - Um campo marcado como `FK` pode ser **obrigatorio ou opcional** dependendo da regra de negocio.
-- A obrigatoriedade especifica esta definida no documento `docs/db/SCHEMA_CONSOLIDATED.md`.
+- A obrigatoriedade especifica esta definida no documento `docs/db/SCHEMA_DECISOES_PENDENTES.md` (canônico, seção Q1-Q15 + D1-D4 + T1-T4). **`docs/db/SCHEMA_CONSOLIDATED.md` está SUPERSEDED — não usar como referência de obrigatoriedade até ser reescrito ou removido (ver aviso no topo daquele arquivo).**
 - **UNIQUE constraints** vao via migration Drizzle (Mermaid nao suporta `UNIQUE` em declaracao de campo).
 - **CHECK constraints** vao via migration Drizzle (Mermaid interpreta `--` e `|` em comentarios como relacoes — usar `text` com descricao em vez de constraint syntax).
 - **Cascade conservador (Q7b=B)**: soft-delete de Imovel toca APENAS `imovel_documento` (junctions). Lancamentos, lancamento_pessoa, Documentos, Pessoas, CRIs **NAO sao tocados** (evidencia preservada).

--- a/docs/db/erd-v2.mmd
+++ b/docs/db/erd-v2.mmd
@@ -1,172 +1,264 @@
 %%{init: {"theme":"neutral","er":{"layoutDirection":"LR","minEntityWidth":180,"minEntityHeight":90,"entityPadding":12},"themeVariables":{"fontSize":"12px"}}}%%
+%% ERD v2 — Cadeia Dominial
+%% Decisões: ver docs/db/SCHEMA_DECISOES_PENDENTES.md (Q1-Q15, Q11b, D1-D4, T1-T4)
+%% Convenções SQLite/D1: TEXT ISO8601 p/ datas, INTEGER 0/1 p/ bool, INTEGER centavos p/ money
+%% CHECK constraints vão via migration Drizzle (Mermaid interpreta -- e | em comentários)
+%% Soft-delete: deleted_at TEXT NULL em todas as tabelas relevantes (Q2=B)
+%% ============================================================================
+%% ⚠️ T4 — Mermaid NÃO é schema. UNIQUE_NOTE é só documentação visual.
+%%    A versão canônica é a Drizzle migration (T-101). Partial UNIQUE indexes
+%%    (`WHERE deleted_at IS NULL`), CHECK constraints, FTS5 sync triggers,
+%%    e a view v_lancamento_current_location (T2) NÃO aparecem no .mmd —
+%%    aplicar via migration Drizzle + SQL DDL.
+%% ============================================================================
 erDiagram
-    cri ||--o{ documento : emite
-    cri ||--o{ imovel : registra
-    imovel ||--o{ documento : possui
-    pessoa ||--o{ imovel : proprietario
-    documento ||--o{ lancamento : gera
-    documento o|--o{ origem : origem_doc
-    lancamento_tipo ||--o{ lancamento : classifica
-    lancamento ||--o{ lancamento_pessoa : envolve
-    pessoa ||--o{ lancamento_pessoa : participa
-    lancamento ||--o{ origem : possui
-    origem ||--o| origem_fim_cadeia : fim_cadeia
-    cri o|--o{ origem : referencia
-    cartorio_transmissao o|--o{ lancamento : transmissao
-    tis ||--o{ tis_imovel : vincula
-    imovel ||--o{ tis_imovel : vincula
-    terra_indigena_referencia ||--o{ tis : referencia
+    cri ||--o{ imovel : "registra (fixo, Q11b=B)"
+    cri ||--o{ documento : "emite (Q11b=C, FK direto, sem junction)"
+    imovel ||--o{ imovel_documento : "pertence (Q13=B, N:N)"
+    documento ||--o{ imovel_documento : "pertence (Q13=B, N:N)"
+    imovel_documento ||--o{ anotacao_versao : "anotado_em (Q9=C)"
+    user ||--o{ anotacao_versao : "autor_original (Q9=C, F1: imutavel, era pessoa)"
+    user ||--o{ anotacao_versao : "created_by (D3, F1: editor, pode diferir do autor original)"
+    user ||--o{ lancamento_move_event : "moved_by (D3, user NAO pessoa)"
+    user ||--o{ audit_log : "actor (D3, user NAO pessoa)"
+    pessoa ||--o{ imovel : "proprietario (pode ser NULL se anonimizado LGPD)"
+    pessoa ||--o{ lancamento_pessoa : "participa (Q2=B, nome_verbatim preservado)"
+    lancamento ||--o{ lancamento_pessoa : "envolve"
+    lancamento_tipo ||--o{ lancamento : "classifica (tipo_id, F3)"
+    documento ||--o{ lancamento : "gera"
+    documento o|--o{ origem : "origem_doc (opcional)"
+    lancamento ||--o{ origem : "possui (1:N, Q3=B)"
+    origem ||--o| origem_fim_cadeia : "fim_cadeia (Q3=B, 1:1 por origem)"
+    cri o|--o{ origem : "cri_origem (Q11b=A, este campo é o cri_origem_id)"
+    lancamento ||--o{ lancamento_move_event : "movido (Q14=B, append-only)"
+    documento ||--o{ lancamento_move_event : "from_doc"
+    documento ||--o{ lancamento_move_event : "to_doc"
+    audit_log ||--o{ lancamento_move_event : "registra"
+    imovel ||--o{ tis_imovel : "vincula_TI"
+    tis ||--o{ tis_imovel : "vincula_TI"
+    terra_indigena_referencia ||--o{ tis : "referencia"
 
     cri {
-      int id PK
-      string nome
-      string cns
-      string estado
-      string cidade
-      string endereco
+        int id PK
+        text nome "1o Cartorio de Registro de Imoveis de Salvador"
+        text cns_codigo "Cadastro Nacional de Serventia, TBD"
+        text cidade
+        text uf "CHECK uf in 27 valores"
+        text endereco
+        text created_at "ISO8601"
+        text updated_at "ISO8601"
+        text deleted_at "soft-delete (Q2=B)"
+        text UNIQUE_NOTE "D1: UNIQUE (cns_codigo) WHERE cns_codigo IS NOT NULL AND deleted_at IS NULL (partial UNIQUE). Duplicatas de nome aceitas (cidade tem 2 1o Cartorio)."
     }
 
-    cartorio_transmissao {
-      int id PK
-      string nome
-      string cns
-      string estado
-      string cidade
-      string endereco
+    user {
+        int id PK
+        text email "UNIQUE, login do pesquisador"
+        text nome "nome de exibicao do pesquisador"
+        text created_at "ISO8601"
+        text updated_at "ISO8601"
+        text deleted_at "soft-delete (Q2=B). LGPD: pesquisador pode pedir anonimizacao do proprio user"
     }
 
     pessoa {
-      int id PK
-      string cpf
-      string rg
-      date data_nascimento
-      string email
-      string telefone
-      string nome
+        int id PK
+        text nome "UNICO campo PII; Q5=REMOVER cpf/rg/email/telefone"
+        text created_at
+        text updated_at
+        text deleted_at "soft-delete (Q2=B). LGPD: NULL + deleted_at preenche, NUNCA hard-delete"
     }
 
     imovel {
-      int id PK
-      string nome
-      string observacoes
-      date data_cadastro
-      int cri_id FK
-      int proprietario_id FK
-      bool arquivado
+        int id PK
+        text nome
+        text observacoes
+        text data_cadastro
+        int cri_id FK "FIXO, sem historico no v1 (Q11b=B)"
+        int proprietario_id FK "pode ser NULL se pessoa anonimizada (LGPD)"
+        integer arquivado "0/1, CHECK in (0,1)"
+        text created_at
+        text updated_at
+        text deleted_at "soft-delete (Q2=B). cascade conservador: I + junctions, L preservados (Q7b=B)"
+        int delete_operation_id FK "audit_log (Q9=C, Q8=A)"
+    }
+
+    imovel_documento {
+        int id PK
+        int imovel_id FK
+        int documento_id FK
+        integer is_documento_atual "0/1, PER-PAR (Imovel,Documento), NAO global (Q13=B)"
+        text created_at
+        text deleted_at "soft-delete per chain membership (Q7b=B)"
+        int delete_operation_id FK "audit_log"
+        int create_operation_id FK "audit_log, Q9=C provenance"
+        text UNIQUE_NOTE "T1: UNIQUE (imovel_id, documento_id) WHERE deleted_at IS NULL (partial UNIQUE). Q15=D4: no max 1 row com is_documento_atual=1 por imovel_id WHERE deleted_at IS NULL (outro partial UNIQUE)"
     }
 
     documento {
-      int id PK
-      string numero
-      string numero_raw
-      date data
-      string livro
-      string folha
-      date data_cadastro
-      int cri_id FK
-      int imovel_id FK
-      string tipo
-      bool is_documento_atual
+        int id PK
+        text tipo "CHECK in (matricula, transcricao)"
+        text numero "normalizado, so digitos"
+        text numero_raw "valor original, so para referencia"
+        text data "ISO8601"
+        text livro
+        text folha
+        text data_cadastro
+        int cri_id FK "FK direto, sem junction (Q11b=C)"
+        text outorgante_nome "busca fuzzy FTS5 (Q10=A, sem _raw)"
+        text outorgado_nome "busca fuzzy FTS5"
+        text endereco "busca fuzzy FTS5"
+        text created_at
+        text deleted_at "soft-delete (Q2=B). Ver Q15: pode afetar N chains"
+        int delete_operation_id FK "audit_log"
+        int create_operation_id FK "audit_log"
+        text UNIQUE_NOTE "UNIQUE (cri_id, tipo, numero) - (Q11b=C) cartorio+tipo+numero"
     }
 
     lancamento_tipo {
-      int id PK
-      string tipo
-      string nome
-      bool requer_detalhes
-      bool requer_transmissao
-      bool requer_cartorio_origem
-      bool requer_data_origem
-      bool requer_descricao
-      bool requer_folha_origem
-      bool requer_forma
-      bool requer_livro_origem
-      bool requer_observacao
-      bool requer_titulo
+        int id PK
+        text tipo "CHECK in (inicio_matricula, registro, averbacao)"
+        text nome "label legivel para UI"
+        integer requer_detalhes "0/1"
+        integer requer_transmissao "0/1"
+        integer requer_cartorio_origem "0/1"
+        integer requer_data_origem "0/1"
+        integer requer_descricao "0/1"
+        integer requer_folha_origem "0/1"
+        integer requer_forma "0/1"
+        integer requer_livro_origem "0/1"
+        integer requer_observacao "0/1"
+        integer requer_titulo "0/1"
     }
 
     lancamento {
-      int id PK
-      date data
-      decimal valor_transacao
-      decimal area
-      string detalhes
-      string observacoes
-      date data_cadastro
-      int documento_id FK
-      int tipo_id FK
-      string descricao
-      string forma
-      string titulo
-      int numero_lancamento
-      int cartorio_transmissao_id FK
-      string livro_transmissao
-      string folha_transmissao
-      date data_transmissao
+        int id PK
+        text data "ISO8601"
+        integer valor_transacao "em CENTAVOS (evita rounding errors)"
+        integer area "em CENTIARES (1 are = 100 m2)"
+        text detalhes
+        text observacoes
+        text data_cadastro
+        int documento_id FK
+        int tipo_id FK
+        text descricao
+        text forma "entrada livre do usuario"
+        text titulo
+        int numero_lancamento "CHECK > 0, pode ser NULL durante migracao"
+        text cartorio_transmissao_nome "FREE-FORM TEXT, SEM FK (Q11b: tabelionato de notas, qualquer um)"
+        text livro_transmissao
+        text folha_transmissao
+        text data_transmissao
+        text created_at
+        text deleted_at "soft-delete (Q2=B). L preservado orfao (Q7b=B)"
+        int delete_operation_id FK "audit_log"
+        text UNIQUE_NOTE "UNIQUE (documento_id, numero_lancamento)"
     }
 
     lancamento_pessoa {
-      int id PK
-      string tipo
-      string nome_digitado
-      int lancamento_id FK
-      int pessoa_id FK
+        int id PK
+        text papel "CHECK in (transmitente, adquirente, etc)"
+        text nome_verbatim "EVIDENCIA preservada mesmo se pessoa_id for NULL (Q2=B)"
+        int lancamento_id FK
+        int pessoa_id FK "pode ser NULL apos LGPD; nome_verbatim persiste"
+        text created_at
+        text deleted_at "soft-delete (Q2=B). NAO cascadear no delete de I (Q7b=B)"
     }
 
     origem {
-      int id PK
-      int lancamento_id FK
-      int cri_id FK
-      int documento_id FK
-      int indice
-      string tipo
-      string numero
-      string livro
-      string folha
-      date data
-      string observacoes
+        int id PK
+        int lancamento_id FK
+        int cri_id FK "CRI de origem (Q11b=A: este campo ja e o cri_origem_id)"
+        int documento_id FK "opcional, NULL se tipo=fim_cadeia"
+        int indice "0, 1, 2..., CHECK >= 0, contiguo por lancamento"
+        text tipo "CHECK in (matricula, transcricao, fim_cadeia)"
+        text numero "so digitos (D2: normalizado pra busca)"
+        text numero_raw "D2: valor original verbatim, evidencia de divergencia entre certidoes"
+        text livro
+        text folha
+        text data
+        text observacoes
+        text created_at
+        text UNIQUE_NOTE "UNIQUE (lancamento_id, indice)"
     }
 
     origem_fim_cadeia {
-      int id PK
-      int origem_id FK
-      string tipo_fim_cadeia
-      string especificacao_fim_cadeia
-      string classificacao_fim_cadeia
-      string sigla_patrimonio_publico
+        int id PK
+        int origem_id FK "UNIQUE 1:1 com origem"
+        text tipo_fim_cadeia "destacamento_publico, sem_origem, outra, etc"
+        text classificacao_fim_cadeia "obrigatoria se tipo_fim_cadeia preenchido"
+        text especificacao_fim_cadeia "obrigatoria se tipo_fim_cadeia=outra"
+        text sigla_patrimonio_publico "obrigatoria se tipo_fim_cadeia=destacamento_publico"
+    }
+
+    anotacao_versao {
+        int id PK
+        int imovel_documento_id FK "junction que recebeu a anotacao"
+        int autor_original_id FK "USER pesquisador que criou originalmente (F1: era pessoa, Q9=C imutavel)"
+        text current_marker "UNIQUE per (imovel_documento_id) WHERE is_current=1, ver partial UNIQUE"
+        integer versao "1, 2, 3..."
+        text texto "anotacao analitica do pesquisador"
+        integer is_current "0/1, partial UNIQUE garante 1 current per junction. is_current=0 = versao antiga, mantida no historico (F2)"
+        text created_at
+        text deleted_at "F2: soft-delete da anotacao INTEIRA (todas versoes). NAO confundir com is_current=0 que so marca versao"
+        int created_by_id FK "USER editor desta versao (D3, pode diferir do autor_original)"
+        int operation_id FK "audit_log (Q9=C, Q8=A)"
+    }
+
+    lancamento_move_event {
+        int id PK
+        int lancamento_id FK
+        int from_documento_id FK
+        int to_documento_id FK
+        text reason "obrigatorio (Q12=D)"
+        int moved_by_id FK "USER pesquisador (D3, nao pessoa)"
+        text moved_at "ISO8601"
+        int audit_log_id FK "audit_log.action=MOVE"
+        text UNIQUE_NOTE "append-only: sem updated_at, sem deleted_at (Q14=B). T2: current location via view v_lancamento_current_location"
+    }
+
+    audit_log {
+        int id PK
+        text operation_id "UUID v4, agrupa eventos de uma operacao atomica"
+        text action "CHECK in (CREATE, EDIT, SOFT_DELETE, RESTORE, MOVE, ANNOTATE, EXPORT)"
+        text entity_type "imovel, documento, lancamento, anotacao, etc"
+        int entity_id
+        text payload_json "snapshot do estado pre-acao"
+        text created_at
+        int actor_id FK "USER pesquisador (D3, nao pessoa)"
     }
 
     tis {
-      int id PK
-      string codigo
-      string etnia
-      date data_cadastro
-      int terra_referencia_id FK
-      decimal area
-      string estado
-      string nome
+        int id PK
+        text codigo
+        text etnia
+        text data_cadastro
+        int terra_referencia_id FK
+        integer area "em centiares"
+        text estado
+        text nome
     }
 
     tis_imovel {
-      int id PK
-      int tis_id FK
-      int imovel_id FK
+        int id PK
+        int tis_id FK
+        int imovel_id FK
+        text UNIQUE_NOTE "UNIQUE (tis_id, imovel_id)"
     }
 
     terra_indigena_referencia {
-      int id PK
-      string codigo
-      string nome
-      string etnia
-      string estado
-      string municipio
-      decimal area_ha
-      string fase
-      string modalidade
-      string coordenacao_regional
-      date data_regularizada
-      date data_homologada
-      date data_declarada
-      date data_delimitada
-      date data_em_estudo
+        int id PK
+        text codigo
+        text nome
+        text etnia
+        text estado
+        text municipio
+        integer area_ha "em centiares (1 ha = 100 are = 10000 m2)"
+        text fase
+        text modalidade
+        text coordenacao_regional
+        text data_regularizada
+        text data_homologada
+        text data_declarada
+        text data_delimitada
+        text data_em_estudo
     }

--- a/docs/db/erd-v2.mmd
+++ b/docs/db/erd-v2.mmd
@@ -194,7 +194,6 @@ erDiagram
         int id PK
         int imovel_documento_id FK "junction que recebeu a anotacao"
         int autor_original_id FK "USER pesquisador que criou originalmente (F1: era pessoa, Q9=C imutavel)"
-        text current_marker "UNIQUE per (imovel_documento_id) WHERE is_current=1, ver partial UNIQUE"
         integer versao "1, 2, 3..."
         text texto "anotacao analitica do pesquisador"
         integer is_current "0/1, partial UNIQUE garante 1 current per junction. is_current=0 = versao antiga, mantida no historico (F2)"


### PR DESCRIPTION
## T-001: Schema v2 — decisions, ERD, and Codex critiques (rounds 1-3 + Opus polish)

Captures the complete set of schema design decisions for the v2 Cadeia Dominial (Drizzle + SQLite/D1), as resolved in the 2026-06-02/03 group sessions with @luandro (decisor) and @Hiure (implementador).

### What this PR adds

- **`docs/db/SCHEMA_DECISOES_PENDENTES.md`** — All 15 questions (Q1–Q15) + Q11b refinement, with options, recommendations, and final decisions. Includes D1–D4 (Codex round 1 decisions), T1–T4 (technical fixes), R3-1 through R3-7 (round 3 inline review fixes), and Opus 4.8 polish.
- **`docs/db/erd-v2.mmd`** — Mermaid ERD (visual documentation only).
- **`docs/db/erd-v2-legend.md`** — Human-readable walkthrough of the ERD.
- **`docs/db/CODEX_CRITIQUE_2026-06-03.md`** — Codex gpt-5.5 (high) round 1 critique.
- **`docs/db/CODEX_CRITIQUE_2026-06-03_ROUND2.md`** — Codex gpt-5.5 (xhigh) round 2 critique.
- **`docs/db/SCHEMA_CONSOLIDATED.md`** — **Marked SUPERSEDED** at top. Not aligned with v2 decisions; canônico agora é SCHEMA_DECISOES_PENDENTES.md + erd-v2.mmd. T-101 will either rewrite or remove this file.

### Key design decisions

| # | Decision | Why |
|---|---|---|
| Q2 | Soft-delete (B) | Researchers copy cartório data verbatim; preserve divergence as grilagem evidence |
| Q7a/Q7b | Soft-delete + junction cascade; L preserved órfão | Evidence preservation |
| Q13 | `imovel_documento` junction (N:N) | Documents can belong to multiple chains |
| Q14 | Append-only MOVE via `lancamento_move_event` | Lancamento is historical, never mutated |
| Q15 | Default = desvincular; admin = apagar; órfão = derived view | Q15=🅳️ |
| D1 | `cri UNIQUE (cns_codigo) WHERE NOT NULL AND deleted_at IS NULL` | Active CNS uniqueness |
| D2 | `origem.numero_raw` verbatim | Same pattern as documento |
| D3 | Separate `user` (researcher) from `pessoa` (cartório) | Distinct identity domains |
| T1 | Partial UNIQUE in `imovel_documento` | Enforce per-par current |
| T2 | SQL view `v_lancamento_current_location` (soft-delete aware) | Deterministic current-location reads, excluding soft-deleted targets |
| T3 | SQLite/D1 conventions (UTC, FTS5 triggers, FK actions, partial dates) | Engine alignment |
| T4 | Mermaid ≠ schema | Drizzle migration is canonical |

### Code review history

- **Codex gpt-5.5 (high)** round 1: 8 findings → D1–D4 + T1–T4 applied.
- **Codex gpt-5.5 (xhigh)** round 2: 2 BLOCKERS (F1, F2) + 1 NICE-TO-HAVE (F3) + 4 textual inconsistencies → all resolved.
- **Codex gpt-5.5 (xhigh) + Greptile** round 3 (inline PR review, 8 threads): triage = **1 BLOCKER + 5 MUST-FIX + 1 NICE-TO-HAVE + 0 DISAGREE → all 7 unique fixes applied** (commit `ca820d7`). Round 3 retry caught R3-2 partial leak (legend:106 requiredness pointer) and R3-1 literal-grep DEGRADED — both fixed in same commit.
- **Opus 4.8** PR readiness review: 4/5. Findings (Q15 status contradictions, `current_marker` phantom column, 3 unresolved Codex threads, view edge case undocumented) all addressed in commit `05eeee9`.
- **Codex gpt-5.5 (xhigh) spot-check** of commit `05eeee9`: 4/4 PASS. **Final verdict: APROVA, no further rounds needed.**
- 3 chatgpt-codex-connector inline threads on the PR replied to and resolved.

### Out of scope (follow-up T-101)

This PR is **docs only**. The actual Drizzle migration (T-101) with partial UNIQUE indexes, CHECK constraints, FTS5 sync triggers, and views will be a separate PR implementing the schema canonically. T-101 should be the only consumer of these docs.

### How to review

1. Start with `docs/db/SCHEMA_DECISOES_PENDENTES.md` (decisions).
2. Reference `docs/db/erd-v2.mmd` + `erd-v2-legend.md` (visual).
3. Read both Codex critiques + the round 3 triage section in the decisions doc to see what was checked.
4. Ignore `docs/db/SCHEMA_CONSOLIDATED.md` — superseded.
5. Diff `feat/t-001-schema-decisions-v2` ← `v2` for line-by-line.

Refs: T-001, T-100, T-101 (follow-up)