### PR TITLE
docs: sync PROGRESS.md + TASKS.md to reflect merged Phase 1.5 work

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -16,6 +16,8 @@
 - **PR #25** — T-101 Drizzle v2 schema (19 files, 17 tables + 2 views). Codex 5/5 R4 ✅ MERGED
 - **PR #26** — T-100 ERD v2 rev1 (schema drift fixes). Codex 5/5 R1 ✅ MERGED
 - **PR #27** — CI fix: pnpm v9→v10, frozen-lockfile, composite action, shared Vitest suite ✅ MERGED
+- **PR #28** — feat(web): minimal React Flow screenshot harness (3-node demo, `pnpm graph:screenshot`, e2e baseline PNG). Codex 5/5 R2 ✅ MERGED
+- **PR #29** — chore(graph): post-merge polish (end-to-end verified, golden positions, fixture happy-path, docu...[truncated]
 
 ## Task Status
 
@@ -29,11 +31,11 @@
 - **T-100** ✅ done — ERD v2 redraw + 1:1 sync. Codex 5/5 APROVA. Branch `docs/erd-v2-rev1` (merged + cleaned)
 - **T-101** ✅ done — Drizzle v2 schema. 19 arquivos em `packages/api/drizzle/schema/` + migration. Codex 5/5 APROVA (round 4). Branch `feat/drizzle-schema-v2` (merged + cleaned)
 
-### Phase 1.5 — Visualization (next)
+### Phase 1.5 — Visualization (in progress)
 
-- **T-500** 📋 ready — Custom node + edge types for `@xyflow/react` graph. **Ready to start**
-- **T-501** 📋 planned — Graph data layer (types, builder, layout, mock)
-- **T-502** 📋 planned — Graph page integration (replace skeleton with full graph view)
+- **T-500** 📋 ready — Custom node + edge types for `@xyflow/react` graph. **Ready to start** (no custom components shipped yet — current demo uses the default node type)
+- **T-501** 🔧 in-progress — Graph data layer partially shipped (PR #28+#29). `types.ts`, `validateGraph` (shape + integrity), `layoutGraph` (dagre LR), `basic-graph.json` fixture, golden positions test, fixture happy-path test. **Still to do:** `generateMockGraph('linear'|'branching'|'merge')`, 100% unit test coverage
+- **T-502** 🔧 in-progress — Graph page partially wired (PR #28+#29). `/graph` route → `GraphPreview` → `validateGraph` → `layoutGraph` → React Flow. **Still to do:** multi-chain mock, node selection, pan/zoom polish, detail panel, Lighthouse ≥ 90
 - **T-503** 📋 planned — API endpoint + real data wiring (blocked on T-202)
 
 ### Phase 2 — Data
@@ -57,10 +59,11 @@
 
 | Worktree | Branch | Status |
 |---|---|---|
-| `CadeiaDominial/` | `v2` | Main checkout |
-| `worktrees/decisions/` | `docs/roadmap-and-pending-decisions` | Long-lived decisions branch |
+| `CadeiaDominial/` | `v2` | Main checkout (clean) |
+| `worktrees/decisions/` | `docs/roadmap-and-pending-decisions` | Long-lived decisions branch (1f69d94) |
+| `worktrees/t-001-v2/` | `feat/t-001-schema-decisions-v2` | T-001 follow-up: 3 unpushed commits (rounds 4-6 review fixes) — out of scope here, owned by Hiure |
 
-All task worktrees cleaned up after merge.
+Graph-harness worktree (PR #28+#29) merged and cleaned up.
 
 ## Key Decisions Summary (Q1-Q15)
 

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -76,7 +76,9 @@ Phase 0: Decisions ──┐
 >
 > **Key docs:** `docs/domain/react-flow-quick-reference.md` (canonical mapping), `docs/domain/tree-model.md` (DAG semantics), `docs/domain/fim-de-cadeia.md` (end-of-chain), `docs/domain/lancamento-tipos.md` (lancamento types).
 >
-> **Current state:** `@xyflow/react ^12.10.0` installed, skeleton `routes/graph.tsx` with 3 hardcoded nodes exists. TanStack Router + React Query wired. No custom nodes, no graph logic, no API endpoint.
+> **Current state (post PR #29, 2026-06-05):** minimal pipeline in place — `@xyflow/react ^12.10.0`, `routes/graph.tsx` → `GraphPreview` → `validateGraph` (accepts `unknown`, returns `GraphJson`) → `layoutGraph` (dagre LR, deterministic) → `<ReactFlow>`. `pnpm graph:screenshot` renders the canonical 3-node basic-graph.json fixture and writes `screenshots/basic-graph.png` (1280×720) for regression-baseline comparison. 26 unit tests including golden positions for the canonical fixture. Custom `DocumentoNode` / `FimCadeiaNode` / `OrigemEdge` components NOT yet shipped (current demo uses the default `default` node type). No API endpoint, mock generators, or `generateMockGraph('linear'|'branching'|'merge')` yet.
+
+> **Status symbols:** ✅ done · 🔧 in-progress (partially shipped) · 📋 ready/planned · 🚫 blocked (see Depends on)
 
 ### T-500 — Custom node + edge types
 - **Status:** 📋 **ready to start**
@@ -87,6 +89,7 @@ Phase 0: Decisions ──┐
   - `FimCadeiaNode` — synthetic leaf (color-coded: origem lídima green, sem origem red, inconclusa yellow)
   - `OrigemEdge` — edge type with origin label (matrícula/transcrição/fim_cadeia)
   - Styling: type-based color scheme matching legacy D3 (matrícula=blue, transcrição=purple, registro=teal)
+  - **Note:** the current 3-node demo (PR #28+#29) uses the default `default` node type — no custom components yet. T-500 ships them.
 - **Acceptance:**
   - Storybook or standalone page renders all 3 node types with sample data
   - Nodes are responsive (readable at 50%-200% zoom)
@@ -96,7 +99,7 @@ Phase 0: Decisions ──┐
 - **Blocks:** T-501
 
 ### T-501 — Graph data layer (types + mock builder)
-- **Status:** blocked on T-500
+- **Status:** 🔧 in-progress (partial: PR #28+#29 landed the types + validate + layout + fixture; mock builders + 100% coverage still pending)
 - **Worktree branch:** `feat/xyflow-graph-data`
 - **Files:** `packages/web/src/lib/graph/`
 - **Description:** Pure TypeScript library that builds `{ nodes, edges }` from domain data:
@@ -104,6 +107,7 @@ Phase 0: Decisions ──┐
   - `builder.ts` — `buildGraph(chainData): GraphData` — maps documentos → nodes, origens → edges, adds synthetic fim-cadeia leaves
   - `layout.ts` — `applyLayout(graphData): GraphData` — BFS from root, `x = depth * 300`, `y = indexWithinDepth * 120`. DAG-aware (nodes can have multiple parents)
   - `mock.ts` — `generateMockGraph(shape): GraphData` — produces 3+ chain shapes (linear, branching, with merge) for development without a backend
+  - **Shipped so far (PR #28+#29):** `types.ts` (named `types.ts` with `GraphJson`/`GraphNode`/`GraphEdge`/`LayoutedNode`), `validateGraph.ts` (accepts `unknown`, validates shape + integrity, returns typed `GraphJson`), `layoutGraph.ts` (dagre LR, deterministic), `toReactFlow.ts` (`graphToReactFlow` adapter), `fixtures/basic-graph.json` (3-node canonical), `validateGraph.test.ts` (13 cases incl. shape validation + canonical fixture happy path), `layoutGraph.test.ts` (7 cases incl. golden positions x=0, 260, 520), `toReactFlow.test.ts` (2 cases), `packages/web/src/graph/README.md` (pipeline docs).
 - **Acceptance:**
   - `buildGraph()` produces valid `{ nodes, edges }` from typed input
   - `applyLayout()` produces non-overlapping positions for graphs up to 100 nodes
@@ -113,7 +117,7 @@ Phase 0: Decisions ──┐
 - **Blocks:** T-502
 
 ### T-502 — Graph page integration
-- **Status:** blocked on T-501
+- **Status:** 🔧 in-progress (partial: PR #28+#29 wired `/graph` → `GraphPreview` → pipeline → React Flow with the canonical 3-node demo; full graph view with detail panel, multi-chain mock, and Lighthouse ≥ 90 still pending)
 - **Worktree branch:** `feat/xyflow-graph-page`
 - **Files:** `packages/web/src/routes/graph.tsx` (rewrite), `packages/web/src/components/graph/GraphView.tsx`
 - **Description:** Replace the hardcoded skeleton with a full-featured graph page:
@@ -122,6 +126,7 @@ Phase 0: Decisions ──┐
   - Interaction: pan, zoom, node click → detail panel (collapsible sidebar or drawer)
   - Fim-de-cadeia: synthetic leaf nodes rendered with classification colors
   - Responsive: works on desktop (1200px+) and tablet (768px+)
+  - **Shipped so far (PR #28+#29):** `routes/graph.tsx` rewritten to use `GraphPreview` + canonical fixture (typed as `unknown`, validated at render time, no `as GraphJson` cast), `packages/web/e2e/graph-screenshot.spec.ts` (Playwright smoke + gated `SAVE_BASELINE=1` write), `packages/web/e2e/graph.spec.ts` (asserts `Field Data` / `Legal Analysis` / `Final Report` text is visible at `/graph`), `screenshots/basic-graph.png` (1280×720 regression baseline, 288 KB), `screenshots/README.md` (regeneration docs).
 - **Acceptance:**
   - `/graph` renders a multi-chain mock graph with 20+ nodes
   - All 3 node types render correctly
@@ -222,8 +227,8 @@ Phase 0: Decisions ──┐
 | T-100 | ✅ done | #26 |
 | T-101 | ✅ done | #25 |
 | **T-500** | 📋 **ready** | — |
-| T-501 | blocked (T-500) | — |
-| T-502 | blocked (T-501) | — |
+| T-501 | 🔧 in-progress (partial: PR #28+#29) | — |
+| T-502 | 🔧 in-progress (partial: PR #28+#29) | — |
 | T-503 | blocked (T-502, T-202) | — |
 | T-200 | 📋 ready | — |
 | T-201 | 📋 ready | — |
@@ -234,7 +239,7 @@ Phase 0: Decisions ──┐
 | T-402 | ✅ done | — |
 | T-403 | ✅ done | #17 |
 
-**Current gate: Phase 1.5 — T-500 ready to start.** Custom node/edge types for `@xyflow/react` graph. Phase 2 (T-200, T-201) can run in parallel if desired.
+**Current gate: Phase 1.5 — T-500 ready to start** (custom node/edge components). T-501 and T-502 partially shipped via PR #28+#29 (pipeline + 3-node demo). Phase 2 (T-200, T-201) can run in parallel if desired.
 
 ---
 


### PR DESCRIPTION
Doc-only sync to reflect PRs #28 and #29 (graph harness + polish) which are now merged on v2.

**PROGRESS.md:**
- Add PR #28 (screenshot harness) and PR #29 (post-merge polish) to the Merged PRs list
- Change Phase 1.5 header from '(next)' to '(in progress)'
- T-501 + T-502 status now in-progress with explicit shipped-vs-pending breakdown
- Active Worktrees table now includes `t-001-v2` (3 unpushed commits, owned by Hiure)
- Drop the stale 'All task worktrees cleaned up after merge' line

**docs/TASKS.md:**
- Replace the 'Current state' blockquote with a detailed description of the pipeline (validateGraph, layoutGraph, fixture, screenshots, 26 tests) and the explicit gaps (no custom node/edge components, no mock generators, no API)
- Add 'Status symbols' legend (done / in-progress / ready / blocked)
- T-500: note that the demo currently uses the default node type
- T-501 + T-502: status in-progress; add 'Shipped so far' sub-block listing the files landed by PRs #28+#29
- Update the status summary table and the 'Current gate' line

**New convention:** introduced one new status symbol (🔧 in-progress) for partially-shipped work. Existing symbols (✅ done, 📋 ready, 🚫 blocked) are unchanged.

**Verification:** docs-only change, no code; CI is expected to be a no-op or trivial. Codex review not solicited for a docs-only sync (codex review protocol is for code-bearing PRs).

Diff: 2 files, +21/-13