### PR TITLE
feat(seed): add field-filler for T-201

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,6 +154,10 @@ importers:
         version: 4.1.8(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(jsdom@24.1.3)(vite@7.3.5(@types/node@25.9.1)(tsx@4.22.4)(yaml@2.9.0))
 
   scripts/seed:
+    dependencies:
+      '@faker-js/faker':
+        specifier: ^9.0.0
+        version: 9.9.0
     devDependencies:
       typescript:
         specifier: ^5.9.3
@@ -1149,6 +1153,10 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@faker-js/faker@9.9.0':
+    resolution: {integrity: sha512-OEl393iCOoo/z8bMezRlJu+GlRGlsKbUAN7jKB6LhnKoqKve5DXRpalbItIIcwnCjs1k/FOPjFzcA6Qn+H+YbA==}
+    engines: {node: '>=18.0.0', npm: '>=9.0.0'}
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -4005,6 +4013,8 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
+
+  '@faker-js/faker@9.9.0': {}
 
   '@humanfs/core@0.19.2':
     dependencies:

--- a/scripts/seed/__tests__/field-filler.test.ts
+++ b/scripts/seed/__tests__/field-filler.test.ts
@@ -1,0 +1,335 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { generateChainTopology } from "../chain-topology.js";
+import { fillFields, generateCpf, validateCpf, generateCnpj, validateCnpj } from "../field-filler.js";
+
+describe("field-filler", () => {
+  describe("generateCpf", () => {
+    it("generates a valid CPF with correct check digits", () => {
+      const cpf = generateCpf();
+      expect(validateCpf(cpf)).toBe(true);
+    });
+
+    it("generates CPF in correct format (ddd.ddd.ddd-dd)", () => {
+      const cpf = generateCpf();
+      expect(cpf).toMatch(/^\d{3}\.\d{3}\.\d{3}-\d{2}$/);
+    });
+
+    it("generates invalid CPF when flag is set", () => {
+      const invalidCpf = generateCpf(true);
+      expect(validateCpf(invalidCpf)).toBe(false);
+    });
+
+    it("generates unique CPFs", () => {
+      const cpfs = new Set<string>();
+      for (let i = 0; i < 100; i++) {
+        cpfs.add(generateCpf());
+      }
+      expect(cpfs.size).toBeGreaterThan(90); // Allow some collisions but expect most to be unique
+    });
+  });
+
+  describe("generateCnpj", () => {
+    it("generates a valid CNPJ with correct check digits", () => {
+      const cnpj = generateCnpj();
+      expect(validateCnpj(cnpj)).toBe(true);
+    });
+
+    it("generates CNPJ in correct format (dd.ddd.ddd/dddd-dd)", () => {
+      const cnpj = generateCnpj();
+      expect(cnpj).toMatch(/^\d{2}\.\d{3}\.\d{3}\/\d{4}-\d{2}$/);
+    });
+
+    it("generates unique CNPJs", () => {
+      const cnpjs = new Set<string>();
+      for (let i = 0; i < 100; i++) {
+        cnpjs.add(generateCnpj());
+      }
+      expect(cnpjs.size).toBeGreaterThan(90);
+    });
+  });
+
+  describe("fillFields", () => {
+    let topology: ReturnType<typeof generateChainTopology>;
+
+    beforeEach(() => {
+      topology = generateChainTopology(12345, 5);
+    });
+
+    it("produces deterministic output with same seed", () => {
+      const filled1 = fillFields(topology, 12345);
+      const filled2 = fillFields(topology, 12345);
+
+      expect(filled1.documentos).toEqual(filled2.documentos);
+      expect(filled1.pessoas).toEqual(filled2.pessoas);
+      expect(filled1.imoveis).toEqual(filled2.imoveis);
+    });
+
+    it("produces different output with different seeds", () => {
+      const filled1 = fillFields(topology, 11111);
+      const filled2 = fillFields(topology, 22222);
+
+      // At least some values should differ
+      const docsDiffer = filled1.documentos.some(
+        (doc, i) => doc.numero !== filled2.documentos[i].numero || doc.data !== filled2.documentos[i].data
+      );
+      expect(docsDiffer).toBe(true);
+    });
+
+    it("produces deterministic output without explicit seed (uses chainId)", () => {
+      const filled1 = fillFields(topology);
+      const filled2 = fillFields(topology);
+
+      expect(filled1.documentos).toEqual(filled2.documentos);
+      expect(filled1.pessoas).toEqual(filled2.pessoas);
+      expect(filled1.imoveis).toEqual(filled2.imoveis);
+    });
+
+    it("generates all topology documentos", () => {
+      const filled = fillFields(topology, 12345);
+
+      expect(filled.documentos.length).toBe(topology.documentos.length);
+      for (const doc of topology.documentos) {
+        expect(filled.documentos.some((d) => d.topologyId === doc.id)).toBe(true);
+      }
+    });
+
+    it("generates pessoas with valid CPFs for pessoa física", () => {
+      const filled = fillFields(topology, 12345);
+
+      const pfPessoas = filled.pessoas.filter((p) => p.tipo === "pf");
+      expect(pfPessoas.length).toBeGreaterThan(0);
+
+      for (const pessoa of pfPessoas) {
+        expect(validateCpf(pessoa.cpfCnpj)).toBe(true);
+      }
+    });
+
+    it("generates pessoas with valid CNPJs for pessoa jurídica", () => {
+      const filled = fillFields(topology, 12345);
+
+      const pjPessoas = filled.pessoas.filter((p) => p.tipo === "pj");
+      // PJ pessoas are random, so we may or may not have them
+      if (pjPessoas.length > 0) {
+        for (const pessoa of pjPessoas) {
+          expect(validateCnpj(pessoa.cpfCnpj)).toBe(true);
+        }
+      }
+    });
+
+    it("generates documento dates that are monotonically increasing", () => {
+      const filled = fillFields(topology, 12345);
+
+      for (let i = 1; i < filled.documentos.length; i++) {
+        const prevDate = new Date(filled.documentos[i - 1].data);
+        const currDate = new Date(filled.documentos[i].data);
+        expect(currDate.getTime()).toBeGreaterThan(prevDate.getTime());
+      }
+    });
+
+    it("generates documento numero format matching tipo", () => {
+      const filled = fillFields(topology, 12345);
+
+      for (let i = 0; i < filled.documentos.length; i++) {
+        const filledDoc = filled.documentos[i];
+        const topoDoc = topology.documentos[i];
+
+        if (topoDoc.tipo === "matricula") {
+          expect(filledDoc.numero).toMatch(/^M-\d{5}$/);
+        } else {
+          expect(filledDoc.numero).toMatch(/^T-\d{5}$/);
+        }
+      }
+    });
+
+    it("generates unique documento numbers within chain", () => {
+      const filled = fillFields(topology, 12345);
+
+      const numeros = filled.documentos.map((d) => d.numero);
+      const uniqueNumeros = new Set(numeros);
+      expect(uniqueNumeros.size).toBe(numeros.length);
+    });
+
+    it("generates realistic person names", () => {
+      const filled = fillFields(topology, 12345);
+
+      const pfPessoas = filled.pessoas.filter((p) => p.tipo === "pf");
+      expect(pfPessoas.length).toBeGreaterThan(0);
+
+      // Verify names are realistic (have at least first and last name)
+      for (const pessoa of pfPessoas) {
+        const nameParts = pessoa.nome.trim().split(/\s+/);
+        expect(nameParts.length).toBeGreaterThanOrEqual(2); // At least first and last name
+        expect(nameParts.every((part) => part.length > 0)).toBe(true);
+      }
+    });
+
+    it("generates imovel with positive area values", () => {
+      const filled = fillFields(topology, 12345);
+
+      expect(filled.imoveis.length).toBe(1);
+      const imovel = filled.imoveis[0];
+
+      expect(imovel.areaTotal).toBeGreaterThan(0);
+      if (imovel.areaReservaLegal !== undefined) {
+        expect(imovel.areaReservaLegal).toBeGreaterThan(0);
+        expect(imovel.areaDemais).toBeDefined();
+        expect(imovel.areaDemais!).toBeGreaterThan(0);
+        expect(imovel.areaReservaLegal + imovel.areaDemais!).toBeCloseTo(imovel.areaTotal, 2);
+      }
+    });
+
+    it("generates imovel with valid UF", () => {
+      const filled = fillFields(topology, 12345);
+
+      const imovel = filled.imoveis[0];
+      const validUFs = [
+        "AC", "AL", "AP", "AM", "BA", "CE", "DF", "ES", "GO", "MA", "MT", "MS",
+        "MG", "PA", "PB", "PR", "PE", "PI", "RJ", "RN", "RS", "RO", "RR", "SC",
+        "SP", "SE", "TO",
+      ];
+      expect(validUFs).toContain(imovel.uf);
+    });
+
+    it("generates imovel with topologyId matching chain imovel", () => {
+      const filled = fillFields(topology, 12345);
+
+      expect(filled.imoveis[0].topologyId).toBe(topology.imovel.id);
+    });
+
+    it("generates chainId matching topology chainId", () => {
+      const filled = fillFields(topology, 12345);
+
+      expect(filled.chainId).toBe(topology.chainId);
+    });
+
+    it("generates 3-5 pessoas per chain", () => {
+      const filled = fillFields(topology, 12345);
+
+      expect(filled.pessoas.length).toBeGreaterThanOrEqual(3);
+      expect(filled.pessoas.length).toBeLessThanOrEqual(5);
+    });
+
+    it("generates pessoas with unique topologyIds", () => {
+      const filled = fillFields(topology, 12345);
+
+      const topologyIds = filled.pessoas.map((p) => p.topologyId);
+      const uniqueIds = new Set(topologyIds);
+      expect(uniqueIds.size).toBe(topologyIds.length);
+    });
+
+    it("generates optional descricao for some documentos", () => {
+      const filled = fillFields(topology, 12345);
+
+      // Some documentos should have descricao, some should not
+      const docsWithDescricao = filled.documentos.filter((d) => d.descricao !== undefined);
+      expect(docsWithDescricao.length).toBeGreaterThan(0);
+      expect(docsWithDescricao.length).toBeLessThan(filled.documentos.length);
+    });
+
+    it("handles linear chain topology", () => {
+      const linearTopology = generateChainTopology(12345, 5, { shape: "linear" });
+      const filled = fillFields(linearTopology, 12345);
+
+      expect(filled.documentos.length).toBe(5);
+      expect(filled.imoveis.length).toBe(1);
+    });
+
+    it("handles branching chain topology", () => {
+      const branchingTopology = generateChainTopology(12345, 5, { shape: "branching" });
+      const filled = fillFields(branchingTopology, 12345);
+
+      expect(filled.documentos.length).toBe(5);
+      expect(filled.imoveis.length).toBe(1);
+    });
+
+    it("handles merge chain topology", () => {
+      const mergeTopology = generateChainTopology(12345, 5, { shape: "merge" });
+      const filled = fillFields(mergeTopology, 12345);
+
+      expect(filled.documentos.length).toBe(5);
+      expect(filled.imoveis.length).toBe(1);
+    });
+
+    it("handles single-document chain", () => {
+      const singleDocTopology = generateChainTopology(12345, 1);
+      const filled = fillFields(singleDocTopology, 12345);
+
+      expect(filled.documentos.length).toBe(1);
+      expect(filled.imoveis.length).toBe(1);
+    });
+
+    it("generates imovel denominacao with capitalized words", () => {
+      const filled = fillFields(topology, 12345);
+
+      const imovel = filled.imoveis[0];
+      // Check that each word starts with capital letter
+      const words = imovel.denominacao.split(" ");
+      for (const word of words) {
+        expect(word[0]).toBe(word[0].toUpperCase());
+      }
+    });
+
+    it("generates documento dates in ISO format (YYYY-MM-DD)", () => {
+      const filled = fillFields(topology, 12345);
+
+      for (const doc of filled.documentos) {
+        expect(doc.data).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+        const date = new Date(doc.data);
+        expect(date.toString()).not.toBe("Invalid Date");
+      }
+    });
+
+    it("generates pessoa names with reasonable length", () => {
+      const filled = fillFields(topology, 12345);
+
+      for (const pessoa of filled.pessoas) {
+        expect(pessoa.nome.length).toBeGreaterThan(2);
+        expect(pessoa.nome.length).toBeLessThan(100);
+      }
+    });
+
+    it("generates municipio name for imovel", () => {
+      const filled = fillFields(topology, 12345);
+
+      const imovel = filled.imoveis[0];
+      expect(imovel.municipio.length).toBeGreaterThan(2);
+      expect(imovel.municipio.length).toBeLessThan(100);
+    });
+  });
+
+  describe("validateCpf", () => {
+    it("rejects CPF with invalid check digits", () => {
+      const invalidCpf = "123.456.789-00"; // Check digits are wrong
+      expect(validateCpf(invalidCpf)).toBe(false);
+    });
+
+    it("rejects CPF with repeated digits", () => {
+      expect(validateCpf("111.111.111-11")).toBe(false);
+      expect(validateCpf("222.222.222-22")).toBe(false);
+    });
+
+    it("rejects malformed CPF", () => {
+      expect(validateCpf("123.456.789")).toBe(false);
+      expect(validateCpf("123.456.789-0")).toBe(false);
+      expect(validateCpf("abc.def.ghi-jk")).toBe(false);
+    });
+  });
+
+  describe("validateCnpj", () => {
+    it("rejects CNPJ with invalid check digits", () => {
+      const invalidCnpj = "12.345.678/0001-00"; // Check digits are wrong
+      expect(validateCnpj(invalidCnpj)).toBe(false);
+    });
+
+    it("rejects CNPJ with repeated digits", () => {
+      expect(validateCnpj("11.111.111/1111-11")).toBe(false);
+      expect(validateCnpj("22.222.222/2222-22")).toBe(false);
+    });
+
+    it("rejects malformed CNPJ", () => {
+      expect(validateCnpj("12.345.678/0001")).toBe(false);
+      expect(validateCnpj("12.345.678/0001-0")).toBe(false);
+      expect(validateCnpj("abc.def.ghi/jkl-mn")).toBe(false);
+    });
+  });
+});

--- a/scripts/seed/field-filler.ts
+++ b/scripts/seed/field-filler.ts
@@ -1,0 +1,403 @@
+import { faker } from "@faker-js/faker";
+import type {
+  TopologyGraph,
+  DocumentoTipo,
+} from "./chain-topology.js";
+
+/**
+ * Simple hash of a string to a number. Used to derive a deterministic seed
+ * from the chainId when no explicit seed is provided.
+ */
+function hashString(str: string): number {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    const char = str.charCodeAt(i);
+    hash = (hash << 5) - hash + char;
+    hash = hash & hash; // Convert to 32bit integer
+  }
+  return Math.abs(hash);
+}
+
+/**
+ * Generate a valid Brazilian CPF with correct check digits.
+ *
+ * CPF format: ddd.ddd.ddd-dd
+ * The last two digits are check digits computed from the first nine.
+ *
+ * Algorithm:
+ * 1. Generate 9 random digits (d1..d9)
+ * 2. Compute first check digit (d10):
+ *    - Multiply d1×10, d2×9, ..., d9×2
+ *    - Sum the products
+ *    - d10 = (sum × 10) % 11; if >= 10, use 0
+ * 3. Compute second check digit (d11):
+ *    - Multiply d1×11, d2×10, ..., d9×3, d10×2
+ *    - Sum the products
+ *    - d11 = (sum × 10) % 11; if >= 10, use 0
+ *
+ * @param invalid - If true, generate an INVALID CPF (for negative tests)
+ */
+export function generateCpf(invalid = false): string {
+  // Generate 9 random digits
+  const digits = Array.from({ length: 9 }, () => faker.number.int({ min: 0, max: 9 }));
+
+  // Compute first check digit
+  let sum = 0;
+  for (let i = 0; i < 9; i++) {
+    sum += digits[i] * (10 - i);
+  }
+  let digit10 = (sum * 10) % 11;
+  if (digit10 >= 10) digit10 = 0;
+
+  // Compute second check digit
+  sum = 0;
+  for (let i = 0; i < 9; i++) {
+    sum += digits[i] * (11 - i);
+  }
+  sum += digit10 * 2;
+  let digit11 = (sum * 10) % 11;
+  if (digit11 >= 10) digit11 = 0;
+
+  // If invalid flag is set, corrupt one of the check digits
+  if (invalid) {
+    digit11 = (digit11 + 1) % 10;
+  }
+
+  const allDigits = [...digits, digit10, digit11];
+  return `${allDigits.slice(0, 3).join("")}.${allDigits.slice(3, 6).join("")}.${allDigits.slice(6, 9).join("")}-${allDigits[9]}${allDigits[10]}`;
+}
+
+/**
+ * Validate a CPF by verifying its check digits.
+ * Returns true if the CPF has valid check digits, false otherwise.
+ */
+export function validateCpf(cpf: string): boolean {
+  const digits = cpf.replace(/\D/g, "");
+  if (digits.length !== 11) return false;
+
+  const nums = digits.split("").map(Number);
+
+  // Check if all digits are the same (invalid CPF pattern)
+  if (nums.every((d) => d === nums[0])) return false;
+
+  // Compute first check digit
+  let sum = 0;
+  for (let i = 0; i < 9; i++) {
+    sum += nums[i] * (10 - i);
+  }
+  const digit10 = (sum * 10) % 11;
+  const expectedDigit10 = digit10 >= 10 ? 0 : digit10;
+  if (nums[9] !== expectedDigit10) return false;
+
+  // Compute second check digit
+  sum = 0;
+  for (let i = 0; i < 9; i++) {
+    sum += nums[i] * (11 - i);
+  }
+  sum += nums[9] * 2;
+  const digit11 = (sum * 10) % 11;
+  const expectedDigit11 = digit11 >= 10 ? 0 : digit11;
+  if (nums[10] !== expectedDigit11) return false;
+
+  return true;
+}
+
+/**
+ * Generate a valid Brazilian CNPJ with correct check digits.
+ *
+ * CNPJ format: dd.ddd.ddd/dddd-dd
+ * The last two digits are check digits computed from the first twelve.
+ */
+export function generateCnpj(): string {
+  // Generate 12 random digits (first 8 are the registration number, next 4 are branch number)
+  const baseDigits = Array.from({ length: 12 }, () => faker.number.int({ min: 0, max: 9 }));
+
+  // Compute first check digit (d13)
+  let sum = 0;
+  const weights1 = [5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
+  for (let i = 0; i < 12; i++) {
+    sum += baseDigits[i] * weights1[i];
+  }
+  let remainder = sum % 11;
+  const digit13 = remainder < 2 ? 0 : 11 - remainder;
+
+  // Compute second check digit (d14)
+  sum = 0;
+  const weights2 = [6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
+  const allButLast = [...baseDigits, digit13];
+  for (let i = 0; i < 13; i++) {
+    sum += allButLast[i] * weights2[i];
+  }
+  remainder = sum % 11;
+  const digit14 = remainder < 2 ? 0 : 11 - remainder;
+
+  const allDigits = [...baseDigits, digit13, digit14];
+  return `${allDigits.slice(0, 2).join("")}.${allDigits.slice(2, 5).join("")}.${allDigits.slice(5, 8).join("")}/${allDigits.slice(8, 12).join("")}-${allDigits[12]}${allDigits[13]}`;
+}
+
+/**
+ * Validate a CNPJ by verifying its check digits.
+ * Returns true if the CNPJ has valid check digits, false otherwise.
+ */
+export function validateCnpj(cnpj: string): boolean {
+  const digits = cnpj.replace(/\D/g, "");
+  if (digits.length !== 14) return false;
+
+  const nums = digits.split("").map(Number);
+
+  // Check if all digits are the same (invalid CNPJ pattern)
+  if (nums.every((d) => d === nums[0])) return false;
+
+  // Compute first check digit
+  let sum = 0;
+  const weights1 = [5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
+  for (let i = 0; i < 12; i++) {
+    sum += nums[i] * weights1[i];
+  }
+  let remainder = sum % 11;
+  const digit13 = remainder < 2 ? 0 : 11 - remainder;
+  if (nums[12] !== digit13) return false;
+
+  // Compute second check digit
+  sum = 0;
+  const weights2 = [6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
+  for (let i = 0; i < 13; i++) {
+    sum += nums[i] * weights2[i];
+  }
+  remainder = sum % 11;
+  const digit14 = remainder < 2 ? 0 : 11 - remainder;
+  if (nums[13] !== digit14) return false;
+
+  return true;
+}
+
+/**
+ * Filled documento with realistic field values.
+ */
+export interface FilledDocumento {
+  /** The documento's topology ID (doc.id) */
+  topologyId: string;
+  /** Document number (e.g. "M-12345" or "T-67890") */
+  numero: string;
+  /** ISO date string (YYYY-MM-DD) */
+  data: string;
+  /** Optional description */
+  descricao?: string;
+}
+
+/**
+ * Filled pessoa (person or legal entity) with realistic field values.
+ */
+export interface FilledPessoa {
+  /** The pessoa's topology ID (referenced entity id) */
+  topologyId: string;
+  /** Full name (person) or company name (legal entity) */
+  nome: string;
+  /** Valid CPF or CNPJ */
+  cpfCnpj: string;
+  /** "pf" for pessoa física (person), "pj" for pessoa jurídica (legal entity) */
+  tipo: "pf" | "pj";
+}
+
+/**
+ * Filled imovel (property) with realistic field values.
+ */
+export interface FilledImovel {
+  /** The imovel's topology ID */
+  topologyId: string;
+  /** Property denomination (e.g. "Fazenda São José") */
+  denominacao: string;
+  /** Total area in hectares */
+  areaTotal: number;
+  /** Legal reserve area in hectares (optional) */
+  areaReservaLegal?: number;
+  /** Remaining area in hectares (optional) */
+  areaDemais?: number;
+  /** Municipality name */
+  municipio: string;
+  /** State abbreviation (UF) */
+  uf: string;
+}
+
+/**
+ * Filled chain with all entities enriched with realistic field values.
+ */
+export interface FilledChain {
+  /** Chain ID from topology */
+  chainId: string;
+  /** Filled documentos */
+  documentos: FilledDocumento[];
+  /** Filled pessoas (persons and legal entities) */
+  pessoas: FilledPessoa[];
+  /** Filled imoveis (properties) */
+  imoveis: FilledImovel[];
+}
+
+/**
+ * Generate a random date within the last 10 years.
+ */
+function randomDate(): Date {
+  const end = new Date();
+  const start = new Date();
+  start.setFullYear(end.getFullYear() - 10);
+  return faker.date.between({ from: start, to: end });
+}
+
+/**
+ * Add a random number of days (30-365) to a date.
+ */
+function addDays(date: Date, days: number): Date {
+  const result = new Date(date);
+  result.setDate(result.getDate() + days);
+  return result;
+}
+
+/**
+ * Format a Date as ISO string (YYYY-MM-DD).
+ */
+function formatDate(date: Date): string {
+  return date.toISOString().split("T")[0];
+}
+
+/**
+ * Get a Brazilian state abbreviation (UF).
+ */
+function randomUf(): string {
+  const ufs = [
+    "AC", "AL", "AP", "AM", "BA", "CE", "DF", "ES", "GO", "MA", "MT", "MS",
+    "MG", "PA", "PB", "PR", "PE", "PI", "RJ", "RN", "RS", "RO", "RR", "SC",
+    "SP", "SE", "TO",
+  ];
+  return faker.helpers.arrayElement(ufs);
+}
+
+/**
+ * Generate a document number based on tipo.
+ * M-XXXXX for matricula, T-XXXXX for transcricao.
+ */
+function generateNumero(tipo: DocumentoTipo, index: number): string {
+  const prefix = tipo === "transcricao" ? "T" : "M";
+  return `${prefix}-${String(index + 1).padStart(5, "0")}`;
+}
+
+/**
+ * Fill non-structural fields in a topology graph with realistic values.
+ *
+ * This function takes a TopologyGraph (from chain-topology.ts) and enriches
+ * it with realistic field values for documents, persons, and properties using
+ * @faker-js/faker with Portuguese locale.
+ *
+ * @param topology - The topology graph to fill
+ * @param seed - Optional seed for deterministic output. If not provided,
+ *               derived from the chainId hash.
+ * @returns Filled chain with all entities enriched with realistic values
+ */
+export function fillFields(topology: TopologyGraph, seed?: number): FilledChain {
+  // Derive seed from chainId if not provided
+  const actualSeed = seed ?? hashString(topology.chainId);
+
+  // Seed faker for deterministic output
+  faker.seed(actualSeed);
+
+  const documentos: FilledDocumento[] = [];
+  const pessoas: FilledPessoa[] = [];
+  const imoveis: FilledImovel[] = [];
+
+  // Track used numbers to ensure uniqueness within chain
+  const usedMatriculaNumbers = new Set<number>();
+  const usedTranscricaoNumbers = new Set<number>();
+
+  // Generate documentos with monotonically increasing dates
+  let currentDate = randomDate();
+  for (let i = 0; i < topology.documentos.length; i++) {
+    const doc = topology.documentos[i];
+
+    // Generate unique number based on tipo
+    let numberIndex = i;
+    if (doc.tipo === "matricula") {
+      while (usedMatriculaNumbers.has(numberIndex)) {
+        numberIndex++;
+      }
+      usedMatriculaNumbers.add(numberIndex);
+    } else {
+      while (usedTranscricaoNumbers.has(numberIndex)) {
+        numberIndex++;
+      }
+      usedTranscricaoNumbers.add(numberIndex);
+    }
+
+    const numero = generateNumero(doc.tipo, numberIndex);
+    const data = formatDate(currentDate);
+
+    // Randomly decide whether to include a description (30% chance)
+    const descricao = faker.datatype.boolean({ probability: 0.3 })
+      ? faker.lorem.sentence({ min: 5, max: 15 })
+      : undefined;
+
+    documentos.push({
+      topologyId: doc.id,
+      numero,
+      data,
+      descricao,
+    });
+
+    // Move to next date (30-365 days later)
+    const daysToAdd = faker.number.int({ min: 30, max: 365 });
+    currentDate = addDays(currentDate, daysToAdd);
+  }
+
+  // Generate pessoas (3-5 per chain)
+  const pessoaCount = faker.number.int({ min: 3, max: 5 });
+  for (let i = 0; i < pessoaCount; i++) {
+    const isPessoaFisica = faker.datatype.boolean({ probability: 0.7 }); // 70% PF, 30% PJ
+
+    if (isPessoaFisica) {
+      pessoas.push({
+        topologyId: `pessoa-pf-${i + 1}`,
+        nome: faker.person.fullName(),
+        cpfCnpj: generateCpf(),
+        tipo: "pf",
+      });
+    } else {
+      pessoas.push({
+        topologyId: `pessoa-pj-${i + 1}`,
+        nome: faker.company.name(),
+        cpfCnpj: generateCnpj(),
+        tipo: "pj",
+      });
+    }
+  }
+
+  // Generate imovel (exactly 1 per chain per S-3)
+  const areaTotal = faker.number.float({ min: 10, max: 10000, fractionDigits: 2 });
+  const hasReservaLegal = faker.datatype.boolean({ probability: 0.8 });
+
+  let areaReservaLegal: number | undefined;
+  let areaDemais: number | undefined;
+
+  if (hasReservaLegal) {
+    // Legal reserve is 20-35% of total area
+    const reservaPercentage = faker.number.float({ min: 0.20, max: 0.35, fractionDigits: 2 });
+    areaReservaLegal = Math.round(areaTotal * reservaPercentage * 100) / 100;
+    areaDemais = Math.round((areaTotal - areaReservaLegal) * 100) / 100;
+  }
+
+  imoveis.push({
+    topologyId: topology.imovel.id,
+    denominacao: faker.lorem.words({ min: 2, max: 4 }).split(" ").map((word) =>
+      word.charAt(0).toUpperCase() + word.slice(1)
+    ).join(" "),
+    areaTotal,
+    areaReservaLegal,
+    areaDemais,
+    municipio: faker.location.city(),
+    uf: randomUf(),
+  });
+
+  return {
+    chainId: topology.chainId,
+    documentos,
+    pessoas,
+    imoveis,
+  };
+}

--- a/scripts/seed/field-filler.ts
+++ b/scripts/seed/field-filler.ts
@@ -1,4 +1,4 @@
-import { faker } from "@faker-js/faker";
+import { Faker, pt_BR, type Faker as FakerType } from "@faker-js/faker";
 import type {
   TopologyGraph,
 } from "./chain-topology.js";
@@ -17,54 +17,48 @@ function hashString(str: string): number {
   return Math.abs(hash);
 }
 
-/**
- * Generate a valid Brazilian CPF with correct check digits.
- *
- * CPF format: ddd.ddd.ddd-dd
- * The last two digits are check digits computed from the first nine.
- *
- * Algorithm:
- * 1. Generate 9 random digits (d1..d9)
- * 2. Compute first check digit (d10):
- *    - Multiply d1×10, d2×9, ..., d9×2
- *    - Sum the products
- *    - d10 = (sum × 10) % 11; if >= 10, use 0
- * 3. Compute second check digit (d11):
- *    - Multiply d1×11, d2×10, ..., d9×3, d10×2
- *    - Sum the products
- *    - d11 = (sum × 10) % 11; if >= 10, use 0
- *
- * @param invalid - If true, generate an INVALID CPF (for negative tests)
- */
-export function generateCpf(invalid = false): string {
-  // Generate 9 random digits
-  const digits = Array.from({ length: 9 }, () => faker.number.int({ min: 0, max: 9 }));
+// ── Fixed date range for deterministic cross-run output ──
+// Anchor to a fixed window (2010–2020) instead of wall-clock time,
+// so that the same seed always produces the same output regardless
+// of when the process runs.  Greptile P1.
+const FIXED_DATE_START = new Date("2010-01-01");
+const FIXED_DATE_END = new Date("2020-12-31");
 
-  // Compute first check digit
+// ── CPF helpers (algorithm — faker-independent) ──
+
+function computeCpfCheckDigits(digits: number[]): [number, number] {
   let sum = 0;
-  for (let i = 0; i < 9; i++) {
-    sum += digits[i] * (10 - i);
-  }
-  let digit10 = (sum * 10) % 11;
-  if (digit10 >= 10) digit10 = 0;
+  for (let i = 0; i < 9; i++) sum += digits[i] * (10 - i);
+  let d10 = (sum * 10) % 11;
+  if (d10 >= 10) d10 = 0;
 
-  // Compute second check digit
   sum = 0;
-  for (let i = 0; i < 9; i++) {
-    sum += digits[i] * (11 - i);
-  }
-  sum += digit10 * 2;
-  let digit11 = (sum * 10) % 11;
-  if (digit11 >= 10) digit11 = 0;
+  for (let i = 0; i < 9; i++) sum += digits[i] * (11 - i);
+  sum += d10 * 2;
+  let d11 = (sum * 10) % 11;
+  if (d11 >= 10) d11 = 0;
 
-  // If invalid flag is set, corrupt a data digit (not a check digit)
+  return [d10, d11];
+}
+
+function generateCpfWithFaker(faker: FakerType, invalid = false): string {
+  const digits = Array.from({ length: 9 }, () => faker.number.int({ min: 0, max: 9 }));
+  const [d10, d11] = computeCpfCheckDigits(digits);
+
   if (invalid) {
-    // Flip one of the first 9 digits to guarantee invalid CPF
     digits[0] = (digits[0] + 1) % 10;
   }
 
-  const allDigits = [...digits, digit10, digit11];
-  return `${allDigits.slice(0, 3).join("")}.${allDigits.slice(3, 6).join("")}.${allDigits.slice(6, 9).join("")}-${allDigits[9]}${allDigits[10]}`;
+  const all = [...digits, d10, d11];
+  return `${all.slice(0, 3).join("")}.${all.slice(3, 6).join("")}.${all.slice(6, 9).join("")}-${all[9]}${all[10]}`;
+}
+
+/**
+ * Generate a valid Brazilian CPF with correct check digits.
+ * Uses a dedicated faker instance for isolation — see generateCpfIsolated.
+ */
+export function generateCpf(invalid = false): string {
+  return generateCpfWithFaker(new Faker({ locale: pt_BR }), invalid);
 }
 
 /**
@@ -77,62 +71,46 @@ export function validateCpf(cpf: string): boolean {
 
   const nums = digits.split("").map(Number);
 
-  // Check if all digits are the same (invalid CPF pattern)
+  // Reject CPFs with all identical digits (e.g., 111.111.111-11)
   if (nums.every((d) => d === nums[0])) return false;
 
-  // Compute first check digit
+  const [expectedD10, expectedD11] = computeCpfCheckDigits(nums.slice(0, 9));
+  return nums[9] === expectedD10 && nums[10] === expectedD11;
+}
+
+// ── CNPJ helpers (algorithm — faker-independent) ──
+
+const CNPJ_WEIGHTS1 = [5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
+const CNPJ_WEIGHTS2 = [6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
+
+function computeCnpjCheckDigits(digits: number[]): [number, number] {
   let sum = 0;
-  for (let i = 0; i < 9; i++) {
-    sum += nums[i] * (10 - i);
-  }
-  const digit10 = (sum * 10) % 11;
-  const expectedDigit10 = digit10 >= 10 ? 0 : digit10;
-  if (nums[9] !== expectedDigit10) return false;
+  for (let i = 0; i < 12; i++) sum += digits[i] * CNPJ_WEIGHTS1[i];
+  const rem1 = sum % 11;
+  const d13 = rem1 < 2 ? 0 : 11 - rem1;
 
-  // Compute second check digit
   sum = 0;
-  for (let i = 0; i < 9; i++) {
-    sum += nums[i] * (11 - i);
-  }
-  sum += nums[9] * 2;
-  const digit11 = (sum * 10) % 11;
-  const expectedDigit11 = digit11 >= 10 ? 0 : digit11;
-  if (nums[10] !== expectedDigit11) return false;
+  for (let i = 0; i < 12; i++) sum += digits[i] * CNPJ_WEIGHTS2[i];
+  sum += d13 * CNPJ_WEIGHTS2[12];
+  const rem2 = sum % 11;
+  const d14 = rem2 < 2 ? 0 : 11 - rem2;
 
-  return true;
+  return [d13, d14];
+}
+
+function generateCnpjWithFaker(faker: FakerType): string {
+  const base = Array.from({ length: 12 }, () => faker.number.int({ min: 0, max: 9 }));
+  const [d13, d14] = computeCnpjCheckDigits(base);
+  const all = [...base, d13, d14];
+  return `${all.slice(0, 2).join("")}.${all.slice(2, 5).join("")}.${all.slice(5, 8).join("")}/${all.slice(8, 12).join("")}-${all[12]}${all[13]}`;
 }
 
 /**
  * Generate a valid Brazilian CNPJ with correct check digits.
- *
- * CNPJ format: dd.ddd.ddd/dddd-dd
- * The last two digits are check digits computed from the first twelve.
+ * Uses a dedicated faker instance for isolation.
  */
 export function generateCnpj(): string {
-  // Generate 12 random digits (first 8 are the registration number, next 4 are branch number)
-  const baseDigits = Array.from({ length: 12 }, () => faker.number.int({ min: 0, max: 9 }));
-
-  // Compute first check digit (d13)
-  let sum = 0;
-  const weights1 = [5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
-  for (let i = 0; i < 12; i++) {
-    sum += baseDigits[i] * weights1[i];
-  }
-  let remainder = sum % 11;
-  const digit13 = remainder < 2 ? 0 : 11 - remainder;
-
-  // Compute second check digit (d14)
-  sum = 0;
-  const weights2 = [6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
-  const allButLast = [...baseDigits, digit13];
-  for (let i = 0; i < 13; i++) {
-    sum += allButLast[i] * weights2[i];
-  }
-  remainder = sum % 11;
-  const digit14 = remainder < 2 ? 0 : 11 - remainder;
-
-  const allDigits = [...baseDigits, digit13, digit14];
-  return `${allDigits.slice(0, 2).join("")}.${allDigits.slice(2, 5).join("")}.${allDigits.slice(5, 8).join("")}/${allDigits.slice(8, 12).join("")}-${allDigits[12]}${allDigits[13]}`;
+  return generateCnpjWithFaker(new Faker({ locale: pt_BR }));
 }
 
 /**
@@ -145,139 +123,80 @@ export function validateCnpj(cnpj: string): boolean {
 
   const nums = digits.split("").map(Number);
 
-  // Check if all digits are the same (invalid CNPJ pattern)
   if (nums.every((d) => d === nums[0])) return false;
 
-  // Compute first check digit
-  let sum = 0;
-  const weights1 = [5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
-  for (let i = 0; i < 12; i++) {
-    sum += nums[i] * weights1[i];
-  }
-  let remainder = sum % 11;
-  const digit13 = remainder < 2 ? 0 : 11 - remainder;
-  if (nums[12] !== digit13) return false;
-
-  // Compute second check digit
-  sum = 0;
-  const weights2 = [6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
-  for (let i = 0; i < 13; i++) {
-    sum += nums[i] * weights2[i];
-  }
-  remainder = sum % 11;
-  const digit14 = remainder < 2 ? 0 : 11 - remainder;
-  if (nums[13] !== digit14) return false;
-
-  return true;
+  const [expectedD13, expectedD14] = computeCnpjCheckDigits(nums.slice(0, 12));
+  return nums[12] === expectedD13 && nums[13] === expectedD14;
 }
 
-/**
- * Filled documento with realistic field values.
- */
+// ── Filled types ──
+
 export interface FilledDocumento {
-  /** The documento's topology ID (doc.id) */
   topologyId: string;
-  /** Document number (e.g. "M-12345" or "T-67890") */
   numero: string;
-  /** ISO date string (YYYY-MM-DD) */
   data: string;
-  /** Optional description */
   descricao?: string;
 }
 
-/**
- * Filled pessoa (person or legal entity) with realistic field values.
- */
 export interface FilledPessoa {
-  /** The pessoa's topology ID (referenced entity id) */
   topologyId: string;
-  /** Full name (person) or company name (legal entity) */
   nome: string;
-  /** Valid CPF or CNPJ */
   cpfCnpj: string;
-  /** "pf" for pessoa física (person), "pj" for pessoa jurídica (legal entity) */
   tipo: "pf" | "pj";
 }
 
-/**
- * Filled imovel (property) with realistic field values.
- */
 export interface FilledImovel {
-  /** The imovel's topology ID */
   topologyId: string;
-  /** Property denomination (e.g. "Fazenda São José") */
   denominacao: string;
-  /** Total area in hectares */
   areaTotal: number;
-  /** Legal reserve area in hectares (optional) */
   areaReservaLegal?: number;
-  /** Remaining area in hectares (optional) */
   areaDemais?: number;
-  /** Municipality name */
   municipio: string;
-  /** State abbreviation (UF) */
   uf: string;
 }
 
-/**
- * Filled chain with all entities enriched with realistic field values.
- */
 export interface FilledChain {
-  /** Chain ID from topology */
   chainId: string;
-  /** Filled documentos */
   documentos: FilledDocumento[];
-  /** Filled pessoas (persons and legal entities) */
   pessoas: FilledPessoa[];
-  /** Filled imoveis (properties) */
   imoveis: FilledImovel[];
 }
 
-/**
- * Generate a random date within the last 10 years.
- */
-function randomDate(): Date {
-  const end = new Date();
-  const start = new Date();
-  start.setFullYear(end.getFullYear() - 10);
-  return faker.date.between({ from: start, to: end });
+// ── Internal helpers (all accept a local faker for isolation) ──
+
+function randomDate(faker: FakerType): Date {
+  return faker.date.between({ from: FIXED_DATE_START, to: FIXED_DATE_END });
 }
 
-/**
- * Add a random number of days (30-365) to a date.
- */
 function addDays(date: Date, days: number): Date {
   const result = new Date(date);
   result.setDate(result.getDate() + days);
   return result;
 }
 
-/**
- * Format a Date as ISO string (YYYY-MM-DD).
- */
 function formatDate(date: Date): string {
   return date.toISOString().split("T")[0];
 }
 
-/**
- * Get a Brazilian state abbreviation (UF).
- */
-function randomUf(): string {
-  const ufs = [
-    "AC", "AL", "AP", "AM", "BA", "CE", "DF", "ES", "GO", "MA", "MT", "MS",
-    "MG", "PA", "PB", "PR", "PE", "PI", "RJ", "RN", "RS", "RO", "RR", "SC",
-    "SP", "SE", "TO",
-  ];
-  return faker.helpers.arrayElement(ufs);
-}
+const BRAZILIAN_UFS = [
+  "AC", "AL", "AP", "AM", "BA", "CE", "DF", "ES", "GO", "MA", "MT", "MS",
+  "MG", "PA", "PB", "PR", "PE", "PI", "RJ", "RN", "RS", "RO", "RR", "SC",
+  "SP", "SE", "TO",
+];
 
+function randomUf(faker: FakerType): string {
+  return faker.helpers.arrayElement(BRAZILIAN_UFS);
+}
 
 /**
  * Fill non-structural fields in a topology graph with realistic values.
  *
- * This function takes a TopologyGraph (from chain-topology.ts) and enriches
- * it with realistic field values for documents, persons, and properties using
- * @faker-js/faker with Portuguese locale.
+ * Uses a **local** Faker instance (not the global singleton) so that
+ * concurrent calls (e.g. parallel Vitest files) cannot corrupt each
+ * other's PRNG streams.  Greptile P3.
+ *
+ * The date range is anchored to a fixed 2010–2020 window so that
+ * the same seed produces identical output across runs.  Greptile P1.
  *
  * @param topology - The topology graph to fill
  * @param seed - Optional seed for deterministic output. If not provided,
@@ -285,33 +204,29 @@ function randomUf(): string {
  * @returns Filled chain with all entities enriched with realistic values
  */
 export function fillFields(topology: TopologyGraph, seed?: number): FilledChain {
-  // Derive seed from chainId if not provided
   const actualSeed = seed ?? hashString(topology.chainId);
 
-  // Seed faker for deterministic output
+  // Local faker instance — isolates PRNG state from concurrent callers
+  const faker = new Faker({ locale: pt_BR });
   faker.seed(actualSeed);
 
   const documentos: FilledDocumento[] = [];
   const pessoas: FilledPessoa[] = [];
   const imoveis: FilledImovel[] = [];
 
-  // Type-specific sequential counters (no gaps)
   let matriculaCounter = 1;
   let transcricaoCounter = 1;
 
-  // Generate documentos with monotonically increasing dates
-  let currentDate = randomDate();
+  let currentDate = randomDate(faker);
   for (let i = 0; i < topology.documentos.length; i++) {
     const doc = topology.documentos[i];
 
-    // Generate sequential number based on tipo
     const numero = doc.tipo === "matricula"
       ? `M-${String(matriculaCounter++).padStart(5, "0")}`
       : `T-${String(transcricaoCounter++).padStart(5, "0")}`;
 
     const data = formatDate(currentDate);
 
-    // Randomly decide whether to include a description (30% chance)
     const descricao = faker.datatype.boolean({ probability: 0.3 })
       ? faker.lorem.sentence({ min: 5, max: 15 })
       : undefined;
@@ -323,34 +238,31 @@ export function fillFields(topology: TopologyGraph, seed?: number): FilledChain 
       descricao,
     });
 
-    // Move to next date (30-365 days later)
     const daysToAdd = faker.number.int({ min: 30, max: 365 });
     currentDate = addDays(currentDate, daysToAdd);
   }
 
-  // Generate pessoas (3-5 per chain)
   const pessoaCount = faker.number.int({ min: 3, max: 5 });
   for (let i = 0; i < pessoaCount; i++) {
-    const isPessoaFisica = faker.datatype.boolean({ probability: 0.7 }); // 70% PF, 30% PJ
+    const isPessoaFisica = faker.datatype.boolean({ probability: 0.7 });
 
     if (isPessoaFisica) {
       pessoas.push({
         topologyId: `pessoa-pf-${i + 1}`,
         nome: faker.person.fullName(),
-        cpfCnpj: generateCpf(),
+        cpfCnpj: generateCpfWithFaker(faker),
         tipo: "pf",
       });
     } else {
       pessoas.push({
         topologyId: `pessoa-pj-${i + 1}`,
         nome: faker.company.name(),
-        cpfCnpj: generateCnpj(),
+        cpfCnpj: generateCnpjWithFaker(faker),
         tipo: "pj",
       });
     }
   }
 
-  // Generate imovel (exactly 1 per chain per S-3)
   const areaTotal = faker.number.float({ min: 10, max: 10000, fractionDigits: 2 });
   const hasReservaLegal = faker.datatype.boolean({ probability: 0.8 });
 
@@ -358,11 +270,9 @@ export function fillFields(topology: TopologyGraph, seed?: number): FilledChain 
   let areaDemais: number | undefined;
 
   if (hasReservaLegal) {
-    // Legal reserve is 20-35% of total area
     const reservaPercentage = faker.number.float({ min: 0.20, max: 0.35, fractionDigits: 2 });
     const rawReserva = areaTotal * reservaPercentage;
     areaReservaLegal = Math.round(rawReserva * 100) / 100;
-    // areaDemais is the remainder, rounded once to avoid float precision issues
     areaDemais = +(areaTotal - areaReservaLegal).toFixed(2);
   }
 
@@ -375,7 +285,7 @@ export function fillFields(topology: TopologyGraph, seed?: number): FilledChain 
     areaReservaLegal,
     areaDemais,
     municipio: faker.location.city(),
-    uf: randomUf(),
+    uf: randomUf(faker),
   });
 
   return {

--- a/scripts/seed/field-filler.ts
+++ b/scripts/seed/field-filler.ts
@@ -1,7 +1,6 @@
 import { faker } from "@faker-js/faker";
 import type {
   TopologyGraph,
-  DocumentoTipo,
 } from "./chain-topology.js";
 
 /**
@@ -58,9 +57,10 @@ export function generateCpf(invalid = false): string {
   let digit11 = (sum * 10) % 11;
   if (digit11 >= 10) digit11 = 0;
 
-  // If invalid flag is set, corrupt one of the check digits
+  // If invalid flag is set, corrupt a data digit (not a check digit)
   if (invalid) {
-    digit11 = (digit11 + 1) % 10;
+    // Flip one of the first 9 digits to guarantee invalid CPF
+    digits[0] = (digits[0] + 1) % 10;
   }
 
   const allDigits = [...digits, digit10, digit11];
@@ -271,14 +271,6 @@ function randomUf(): string {
   return faker.helpers.arrayElement(ufs);
 }
 
-/**
- * Generate a document number based on tipo.
- * M-XXXXX for matricula, T-XXXXX for transcricao.
- */
-function generateNumero(tipo: DocumentoTipo, index: number): string {
-  const prefix = tipo === "transcricao" ? "T" : "M";
-  return `${prefix}-${String(index + 1).padStart(5, "0")}`;
-}
 
 /**
  * Fill non-structural fields in a topology graph with realistic values.
@@ -303,30 +295,20 @@ export function fillFields(topology: TopologyGraph, seed?: number): FilledChain 
   const pessoas: FilledPessoa[] = [];
   const imoveis: FilledImovel[] = [];
 
-  // Track used numbers to ensure uniqueness within chain
-  const usedMatriculaNumbers = new Set<number>();
-  const usedTranscricaoNumbers = new Set<number>();
+  // Type-specific sequential counters (no gaps)
+  let matriculaCounter = 1;
+  let transcricaoCounter = 1;
 
   // Generate documentos with monotonically increasing dates
   let currentDate = randomDate();
   for (let i = 0; i < topology.documentos.length; i++) {
     const doc = topology.documentos[i];
 
-    // Generate unique number based on tipo
-    let numberIndex = i;
-    if (doc.tipo === "matricula") {
-      while (usedMatriculaNumbers.has(numberIndex)) {
-        numberIndex++;
-      }
-      usedMatriculaNumbers.add(numberIndex);
-    } else {
-      while (usedTranscricaoNumbers.has(numberIndex)) {
-        numberIndex++;
-      }
-      usedTranscricaoNumbers.add(numberIndex);
-    }
+    // Generate sequential number based on tipo
+    const numero = doc.tipo === "matricula"
+      ? `M-${String(matriculaCounter++).padStart(5, "0")}`
+      : `T-${String(transcricaoCounter++).padStart(5, "0")}`;
 
-    const numero = generateNumero(doc.tipo, numberIndex);
     const data = formatDate(currentDate);
 
     // Randomly decide whether to include a description (30% chance)
@@ -378,8 +360,10 @@ export function fillFields(topology: TopologyGraph, seed?: number): FilledChain 
   if (hasReservaLegal) {
     // Legal reserve is 20-35% of total area
     const reservaPercentage = faker.number.float({ min: 0.20, max: 0.35, fractionDigits: 2 });
-    areaReservaLegal = Math.round(areaTotal * reservaPercentage * 100) / 100;
-    areaDemais = Math.round((areaTotal - areaReservaLegal) * 100) / 100;
+    const rawReserva = areaTotal * reservaPercentage;
+    areaReservaLegal = Math.round(rawReserva * 100) / 100;
+    // areaDemais is the remainder, rounded once to avoid float precision issues
+    areaDemais = +(areaTotal - areaReservaLegal).toFixed(2);
   }
 
   imoveis.push({

--- a/scripts/seed/package.json
+++ b/scripts/seed/package.json
@@ -10,6 +10,9 @@
     "test:unit": "vitest run",
     "typecheck": "tsc --noEmit"
   },
+  "dependencies": {
+    "@faker-js/faker": "^9.0.0"
+  },
   "devDependencies": {
     "vitest": "^4.0.18",
     "typescript": "^5.9.3"


### PR DESCRIPTION
## T-201 — Field Filler

Enriches TopologyGraph (from T-200) with realistic field values using `@faker-js/faker`.

### What's included
- **`scripts/seed/field-filler.ts`** — `fillFields(topology, seed?)` generates:
  - CPF/CNPJ with valid check digits (custom algorithm, not faker's broken one)
  - Sequential document numbers (M-00001, T-00001) per tipo
  - Monotonically increasing ISO dates (30-365 day intervals)
  - 3-5 pessoas per chain (70% PF / 30% PJ)
  - Imovel data (area, reserva legal, municipality, UF)
- **Tests**: 38 test cases covering determinism, CPF/CNPJ validation, date ordering, format checks

### Review cycle
- ✅ Claude Opus Round 1: 3 MUST-FIX → all resolved
- ✅ Claude Opus Round 2: 0 MUST-FIX / 0 NICE → APROVA

### CI
- 193/193 tests pass
- Typecheck passes
- Lint passes