### PR TITLE
feat(graph): add buildGraph + generateMockGraph (T-501)

### DIFF
--- a/.hermes/plans/T-501.md
+++ b/.hermes/plans/T-501.md
@@ -1,0 +1,556 @@
+# T-501 — Graph data layer (buildGraph + generateMockGraph)
+
+## Spec verbatim
+
+From `docs/TASKS.md` lines 101-117:
+
+```
+### T-501 — Graph data layer (types + mock builder)
+- **Status:** 🔧 in-progress (partial: PR #28+#29 landed the types + validate + layout + fixture; mock builders + 100% coverage still pending)
+- **Worktree branch:** `feat/xyflow-graph-data`
+- **Files:** `packages/web/src/lib/graph/`
+- **Description:** Pure TypeScript library that builds `{ nodes, edges }` from domain data:
+  - `types.ts` — `CadeiaNode`, `CadeiaEdge`, `GraphData`, `ChainShape` types
+  - `builder.ts` — `buildGraph(chainData): GraphData` — maps documentos → nodes, origens → edges, adds synthetic fim-cadeia leaves
+  - `layout.ts` — `applyLayout(graphData): GraphData` — BFS from root, `x = depth * 300`, `y = indexWithinDepth * 120`. DAG-aware (nodes can have multiple parents)
+  - `mock.ts` — `generateMockGraph(shape): GraphData` — produces 3+ chain shapes (linear, branching, with merge) for development without a backend
+  - **Shipped so far (PR #28+#29):** `types.ts` (named `types.ts` with `GraphJson`/`GraphNode`/`GraphEdge`/`LayoutedNode`), `validateGraph.ts` (accepts `unknown`, validates shape + integrity, returns typed `GraphJson`), `layoutGraph.ts` (dagre LR, deterministic), `toReactFlow.ts` (`graphToReactFlow` adapter), `fixtures/basic-graph.json` (3-node canonical), `validateGraph.test.ts` (13 cases incl. shape validation + canonical fixture happy path), `layoutGraph.test.ts` (7 cases incl. golden positions x=0, 260, 520), `toReactFlow.test.ts` (2 cases), `packages/web/src/graph/README.md` (pipeline docs).
+- **Acceptance:**
+  - `buildGraph()` produces valid `{ nodes, edges }` from typed input
+  - `applyLayout()` produces non-overlapping positions for graphs up to 100 nodes
+  - `generateMockGraph('linear'|'branching'|'merge')` returns deterministic output
+  - 100% unit test coverage on pure functions
+```
+
+## Context recap
+
+**Already shipped (PR #28+#29):**
+- `types.ts` — `GraphJson`, `GraphNode`, `GraphEdge`, `DocumentoData`, `FimCadeiaData`, `OrigemTipo` types
+- `validateGraph.ts` — 13 test cases, validates `unknown` → `GraphJson` with integrity checks
+- `layoutGraph.ts` — 7 test cases, dagre LR layout with golden position assertions
+- `toReactFlow.ts` — 2 test cases, adapts `LayoutedGraph` to React Flow shapes
+- `topology-adapter.ts` — Converts `TopologyGraph` → `GraphJson` (parallel API, NOT being replaced)
+- `GraphPreview.tsx` — React Flow renderer component
+- `fixtures/basic-graph.json` — Canonical 3-node (2 doc + 1 fim) fixture
+- `README.md` — Pipeline documentation
+- `index.ts` — Public barrel (already exports existing functions)
+
+**What T-501 still owes:**
+1. `builder.ts` — `buildGraph(chainData): GraphJson` taking typed domain input
+2. `mock.ts` — `generateMockGraph(shape): GraphJson` returning deterministic output
+3. 100% unit test coverage on these new pure functions
+4. Update `index.ts` to export the new functions
+5. Update `README.md` to document the new files
+6. Update `docs/TASKS.md` T-501 status from "in-progress" → "ready for review"
+
+## Constraint reconciliation
+
+### 1. builder.ts vs topology-adapter.ts
+
+**Decision:** These are parallel APIs, not competing implementations.
+
+- `topology-adapter.ts` already converts `TopologyGraph` (from `@cadeia/chain-topology`) → `GraphJson`. It takes a **rich seed-script output** with full topology metadata.
+- `buildGraph()` will take a **minimal typed domain input** (`ChainData` — a simple object with `documentos[]`, `lancamentos[]`, `origens[]` arrays). This is for direct API responses or user-provided data, NOT the rich seeded shape.
+
+**Input shape decision:** `ChainData` object (single parameter) with:
+```typescript
+interface ChainData {
+  documentos: Array<{
+    id: string;
+    numero: string;
+    tipo: DocumentoTipo;
+    cartorioId: string;
+    data: string; // ISO date
+  }>;
+  lancamentos: Array<{
+    id: string;
+    documentoId: string;
+    tipo: LancamentoTipo; // from chain-topology
+  }>;
+  origens: Array<{
+    id: string;
+    lancamentoId: string;
+    documentoId: string; // source documento
+    tipoOrigem?: OrigemTipo; // optional, infer from source if missing
+  }>;
+}
+```
+
+Rationale: Single object is readable, future-proof, and matches the pattern of `TopologyGraph` for easy comparison, but it's NOT the same type—`ChainData` is minimal, `TopologyGraph` is rich.
+
+### 2. layoutGraph.ts (dagre LR) vs spec line 108 (BFS layout)
+
+**Decision:** Do NOT replace `layoutGraph.ts`. The dagre LR layout is already shipped and tested. Spec line 108 mentioning "BFS from root, `x = depth * 300`, `y = indexWithinDepth * 120`" is stale pre-PR#28+#29 planning.
+
+If a custom BFS layout is needed in the future, it should be a new function with a different name (e.g., `bfsLayoutGraph`) added alongside `layoutGraph`, not a replacement.
+
+**Plan impact:** No changes to `layoutGraph.ts`. T-501 acceptance bullet "applyLayout() produces non-overlapping positions" is already satisfied by the existing `layoutGraph.ts` (7 test cases pass). The spec line 108 artifact is a documentation bug, not an implementation requirement.
+
+### 3. Coverage tooling gap (Pitfall #13)
+
+**Current state:**
+- `vitest.config.ts` has coverage configured (`provider: v8`, threshold 80%)
+- `@vitest/coverage-v8` is NOT in `packages/web/package.json`
+- `pnpm test:unit` runs `vitest run` without `--coverage` flag
+
+**Plan fix:**
+- Install `@vitest/coverage-v8` in S-1
+- Add `test:unit:coverage` script to `package.json`: `"vitest run --coverage"`
+- Run coverage in S-4 and S-5 acceptance
+
+### 4. Threshold reconciliation: 80% global vs 100% pure functions
+
+**Decision:** Raise the global threshold to 100% for T-501 scope.
+
+Rationale:
+- The new files (`builder.ts`, `mock.ts`) are pure functions—easy to cover fully
+- Existing shipped files (`validateGraph.ts`, `layoutGraph.ts`, `toReactFlow.ts`) already have strong coverage
+- Setting 100% globally for this PR aligns with Phase 1.5+ standard and avoids complex per-file configuration
+
+**Plan fix:** Update `vitest.config.ts` lines 24-27 from 80 → 100 in S-1.
+
+## Subtasks
+
+### S-1: Install coverage tooling and raise thresholds
+
+**Files:** `packages/web/package.json:13-16` (modify scripts), `vitest.config.ts:24-27` (modify thresholds), `packages/web/package.json:38` (add devDependency)
+
+**Scope:**
+1. Add `@vitest/coverage-v8` to `devDependencies` in `package.json`
+2. Add `"test:unit:coverage": "vitest run --coverage"` to `scripts`
+3. Update `vitest.config.ts`: change `lines/functions/branches/statements: 80` to `100`
+4. Verify the new script runs without error (it will fail on existing coverage < 100%, which is expected—this documents the gap)
+
+**Acceptance:**
+- `pnpm install` exits 0 (package installs cleanly)
+- `pnpm test:unit:coverage` runs and produces a coverage report (will show < 100% on existing files, which is expected and documented)
+- `vitest.config.ts` shows thresholds of 100
+
+**Estimated time:** 5 minutes
+
+---
+
+### S-2: Create builder.ts with buildGraph() function
+
+**Files:** `packages/web/src/graph/builder.ts` (create), `packages/web/src/graph/types.ts:1-31` (read for reference)
+
+**Scope:**
+Create `builder.ts` with:
+
+1. **Input type definition** (`ChainData`):
+```typescript
+export interface ChainData {
+  documentos: Array<{
+    id: string;
+    numero: string;
+    tipo: DocumentoTipo;
+    cartorioId: string;
+    data: string;
+  }>;
+  lancamentos: Array<{
+    id: string;
+    documentoId: string;
+    tipo: "registro" | "averbacao" | "inicio_matricula";
+  }>;
+  origens: Array<{
+    id: string;
+    lancamentoId: string;
+    documentoId: string; // source documento ID
+    tipoOrigem?: OrigemTipo; // optional, infer from source doc.tipo if missing
+  }>;
+}
+```
+
+2. **`buildGraph(chainData): GraphJson` function** that:
+   - Maps each `ChainData.documentos[]` → `GraphNode` with `type: "documento"`, `id` prefixed with `doc-` if not already
+   - Maps each `ChainData.origens[]` → `GraphEdge`:
+     - `source` = `origem.documentoId` (source documento)
+     - `target` = `lancamento.documentoId` (target documento, found via `origem.lancamentoId`)
+     - `data.tipoOrigem` = inferred from source document's `tipo` if not provided
+   - **Adds synthetic `fim-cadeia` leaves**: For each documento that has NO outgoing origem (i.e., it's never the `source` of any `origem`), create:
+     - `GraphNode` with `type: "fimCadeia"`, `id: "fim-{docId}"`, `data.classificacao: "inconclusa"`
+     - `GraphEdge` from the documento to the synthetic fim node with `data.tipoOrigem: "fim_cadeia"`
+   - Calls `validateGraph()` on the constructed graph before returning (defense in depth)
+   - Throws on invalid input (missing documento references, cycles, etc.)
+
+3. **ID prefix rules** (must match `validateGraph.ts`):
+   - Documentos: `doc-` prefix (enforce or add if missing)
+   - Fim cadeia: `fim-` prefix
+   - Edge IDs: use `origem.id` for documento→documento edges; synthesize as `{docId}->fim-{docId}` for synthetic edges
+
+**Acceptance:**
+- `builder.ts` exports `buildGraph` and `ChainData` type
+- `pnpm typecheck` exits 0 (no TypeScript errors)
+- `pnpm lint` exits 0
+
+**Estimated time:** 20 minutes
+
+---
+
+### S-3: Create mock.ts with generateMockGraph() function
+
+**Files:** `packages/web/src/graph/mock.ts` (create)
+
+**Scope:**
+Create `mock.ts` with:
+
+1. **Shape parameter type**: `type MockShape = "linear" | "branching" | "merge"`
+
+2. **`generateMockGraph(shape: MockShape): GraphJson` function** that:
+   - Returns **deterministic** output (same shape → same graph every time)
+   - NO random number generator—pure construction with hardcoded data
+   - **Linear shape**: 5 documentos in a chain: `doc-1 → doc-2 → doc-3 → doc-4 → doc-5 → fim-5`
+   - **Branching shape**: 1 root, 2 branches, 2 leaves:
+     ```
+     doc-1 → doc-2 → doc-3 → fim-3
+              → doc-4 → fim-4
+     ```
+   - **Merge shape**: 2 sources merge into 1 target:
+     ```
+     doc-1 → doc-3 → fim-3
+     doc-2 ↗
+     ```
+   - Each documento includes realistic data: `numero` (M1, M2, T1, etc.), `tipo`, `cartorioId`, `data` (ISO dates)
+   - Calls `validateGraph()` before returning
+
+3. **Helper to create synthetic fim nodes** (reuse pattern from `buildGraph`):
+   - Any documento with no outgoing edge gets a `fim-cadeia` leaf
+   - Varies `classificacao` across shapes to test all three values:
+     - Linear: use `inconclusa` for consistency
+     - Branching: use `origem_lidima` for one leaf, `sem_origem` for another (varied)
+     - Merge: use `inconclusa`
+
+**Acceptance:**
+- `mock.ts` exports `generateMockGraph` and `MockShape` type
+- `pnpm typecheck` exits 0
+- `pnpm lint` exits 0
+
+**Estimated time:** 15 minutes
+
+---
+
+### S-4: Write builder.test.ts with 100% coverage
+
+**Files:** `packages/web/src/graph/builder.test.ts` (create)
+
+**Scope:**
+Create test file covering:
+
+1. **Happy paths (3 cases)**:
+   - Single documento with no origens → adds synthetic fim-cadeia leaf
+   - Linear chain of 3 documentos → correct edges + synthetic leaf on last
+   - Branching (1→2) → both branches get synthetic leaves
+
+2. **Edge mapping (3 cases)**:
+   - Edge with `tipoOrigem` provided → uses provided value
+   - Edge without `tipoOrigem` → infers from source documento (matricula → matricula, transcrição → transcrição)
+   - Multiple edges from same source documento → all edges correct
+
+3. **ID prefix enforcement (2 cases)**:
+   - Documento ID without `doc-` prefix → adds it automatically
+   - Synthetic fim node ID → has `fim-` prefix
+
+4. **Validation integration (2 cases)**:
+   - Calls `validateGraph()` internally → returns valid `GraphJson`
+   - Invalid input (e.g., origem references non-existent lancamento) → throws
+
+5. **Synthetic leaf classification (1 case)**:
+   - Synthetic fim-cadeia nodes have `classificacao: "inconclusa"`
+
+**Total: ~11 test cases, covering all branches**
+
+**Acceptance:**
+- `pnpm test:unit` passes all builder tests
+- `pnpm test:unit:coverage` shows 100% coverage on `builder.ts` (lines, functions, branches, statements)
+
+**Estimated time:** 20 minutes
+
+---
+
+### S-5: Write mock.test.ts with 100% coverage
+
+**Files:** `packages/web/src/graph/mock.test.ts` (create)
+
+**Scope:**
+Create test file covering:
+
+1. **Determinism (3 cases)**:
+   - `generateMockGraph("linear")` called twice → returns byte-identical results
+   - `generateMockGraph("branching")` called twice → returns byte-identical results
+   - `generateMockGraph("merge")` called twice → returns byte-identical results
+
+2. **Shape verification (3 cases)**:
+   - Linear: 5 documentos, 4 documento→documento edges, 1 synthetic fim leaf
+   - Branching: 4 documentos, 3 documento→documento edges, 2 synthetic fim leaves
+   - Merge: 3 documentos, 2 documento→documento edges, 1 synthetic fim leaf
+
+3. **Node data completeness (1 case)**:
+   - All mock nodes have required `data` fields (numero, tipo, cartorioId, data for documentos; classificacao for fim)
+
+4. **Validation integration (1 case)**:
+   - Output passes `validateGraph()` (called internally, verified by lack of throw)
+
+**Total: ~8 test cases, covering all branches**
+
+**Acceptance:**
+- `pnpm test:unit` passes all mock tests
+- `pnpm test:unit:coverage` shows 100% coverage on `mock.ts`
+
+**Estimated time:** 15 minutes
+
+---
+
+### S-6: Update index.ts barrel export
+
+**Files:** `packages/web/src/graph/index.ts:1-38` (modify)
+
+**Scope:**
+Add exports for the new functions:
+
+```typescript
+// Add after line 4 (after toReactFlow export):
+export { buildGraph, type ChainData } from "./builder";
+
+// Add after line 4 (or immediately after builder):
+export { generateMockGraph, type MockShape } from "./mock";
+```
+
+**Acceptance:**
+- `pnpm typecheck` exits 0 (exports resolve correctly)
+- `grep -E "buildGraph|generateMockGraph packages/web/src/graph/index.ts` shows both exports
+
+**Estimated time:** 2 minutes
+
+---
+
+### S-7: Update README.md and TASKS.md
+
+**Files:** `packages/web/src/graph/README.md:1-53` (modify), `docs/TASKS.md:101-117` (modify)
+
+**Scope:**
+
+1. **Update `README.md`**:
+   - Add rows to the files table for `builder.ts` and `mock.ts`:
+     ```
+     | `builder.ts` | Builds `{ nodes, edges }` from typed domain input (ChainData). | `ChainData` → `GraphJson` |
+     | `mock.ts` | Deterministic mock generators for development. | `MockShape` → `GraphJson` |
+     ```
+   - Add a section "## Building graphs from domain data" with `buildGraph()` usage example
+   - Add a section "## Mock data for development" with `generateMockGraph()` usage example
+
+2. **Update `docs/TASKS.md` line 102**:
+   - Change `**Status:** 🔧 in-progress (partial: PR #28+#29 landed the types + validate + layout + fixture; mock builders + 100% coverage still pending)`
+   - To: `**Status:** 🔧 ready for review` (or leave for PR description to say, but the file should reflect completion)
+
+**Acceptance:**
+- `README.md` documents both new functions with usage examples
+- `docs/TASKS.md` line 102 shows "ready for review" (or remove the in-progress note)
+
+**Estimated time:** 5 minutes
+
+---
+
+## Risks & open questions
+
+### 1. Coverage tooling gap (Pitfall #13)
+
+**Risk:** Without installing `@vitest/coverage-v8`, the acceptance gate "100% unit test coverage on pure functions" cannot be verified.
+
+**Mitigation:** S-1 installs the tool and adds the `test:unit:coverage` script. The plan explicitly includes this step as S-1 (blocking S-4 and S-5).
+
+### 2. Threshold reconciliation: 80% global config vs 100% acceptance
+
+**Risk:** Existing files (`GraphPreview.tsx`, fixtures, etc.) may not meet 100% coverage, causing `test:unit:coverage` to fail even though new pure functions are fully covered.
+
+**Decision:** Raise global threshold to 100%. The existing shipped files (`validateGraph.ts`, `layoutGraph.ts`, `toReactFlow.ts`) already have strong coverage. If any file falls short, either:
+- Add the missing tests (acceptable for pure functions)
+- Exclude non-pure modules in `vitest.config.ts` `exclude` array (already excludes `e2e`, `node_modules`, `test`)
+
+**Plan note:** S-1 raises thresholds. If coverage reports gaps on existing files, the implementer should add minimal tests OR exclude in config. The acceptance gate focuses on 100% for `builder.ts` and `mock.ts` specifically.
+
+### 3. Builder's typed input shape: ChainData object vs multiple args
+
+**Decision:** `ChainData` object (single parameter).
+
+**Rationale:**
+- More readable and self-documenting than 4+ positional parameters
+- Future-proof: easy to add fields without breaking call sites
+- Matches `TopologyGraph` pattern for easy mental model (but NOT the same type—`ChainData` is minimal)
+- Allows type-safe partial application if needed later
+
+**Type definition** (as specified in S-2):
+```typescript
+interface ChainData {
+  documentos: Array<{ id: string; numero: string; tipo: DocumentoTipo; cartorioId: string; data: string }>;
+  lancamentos: Array<{ id: string; documentoId: string; tipo: "registro" | "averbacao" | "inicio_matricula" }>;
+  origens: Array<{ id: string; lancamentoId: string; documentoId: string; tipoOrigem?: OrigemTipo }>;
+}
+```
+
+### 4. Synthetic fim-cadeia classification value
+
+**Decision:** Use `classificacao: "inconclusa"` for all synthetic leaves generated by `buildGraph()`.
+
+**Rationale:** Consistent with T-200's `chain-topology.ts` which uses `inconclusa` for the same purpose (synthetic chain ends). Mock generators can vary classifications (as specified in S-3) to test all three values.
+
+### 5. Determinism of generateMockGraph
+
+**Decision:** Pure construction, no PRNG. Hardcode the node and edge data.
+
+**Rationale:**
+- Determinism by construction—no seed-based randomness needed
+- Simpler implementation (no `createRng` dependency)
+- Easier to review and maintain
+- Accepts `MockShape` parameter only (no seed arg)
+
+### 6. Round-tripping validateGraph: call internally or trust construction?
+
+**Decision:** Call `validateGraph()` internally in both `buildGraph()` and `generateMockGraph()` before returning.
+
+**Rationale:** Defense in depth. Even though these are pure functions that "should" produce valid output, calling the validator:
+- Catches any bugs in the construction logic
+- Makes the API user-facing safe (callers don't need to re-validate)
+- Aligns with the "validation at boundary" principle
+
+### 7. Fixture files vs code-only mocks
+
+**Decision:** Keep mock generation in code only. No new fixture files.
+
+**Rationale:**
+- S-3 generates deterministic graphs on demand—no need to commit `.json` files
+- The existing `fixtures/basic-graph.json` is kept as the canonical regression fixture
+- Future shape variations can be added by extending `MockShape` type, not adding files
+
+## Out of scope
+
+T-501 explicitly does NOT cover:
+
+1. **T-502** — Full graph page with detail panel + Lighthouse ≥ 90
+2. **T-503** — API endpoint wiring
+3. **Replacing `layoutGraph.ts`** — dagre LR layout is shipped and working
+4. **Replacing `topology-adapter.ts`** — `buildGraph` is a parallel API for typed domain input; `topology-adapter` remains for `TopologyGraph` → `GraphJson`
+5. **Snapshot tests for rendered output** — T-500 owns that
+6. **Custom node/edge components** — T-500 owns that (DocumentoNode, FimCadeiaNode, OrigemEdge)
+
+## Hermes independent verdict (post-Opus)
+
+**Verdict perspective:** the planner optimized for clarity and "single object" ergonomics. I reviewed for **type-system contract alignment** with the existing `topology-adapter.ts` and the `chain-topology` source-of-truth — that's an angle the planner didn't lean into.
+
+**Round-1 verdict: 0 PASS / 4 MUST-FIX / 2 NICE / 0 DISAGREE**
+
+### MUST-FIX (implementer MUST address before commit)
+
+#### MUST-FIX #1: `LancamentoTipo` should be imported, not redefined inline
+
+**Plan location:** S-2 scope, the inline `tipo: "registro" | "averbacao" | "inicio_matricula"` in the `ChainData` interface.
+
+**Issue:** `scripts/seed/chain-topology.ts:11` already exports `export type LancamentoTipo = "registro" | "averbacao" | "inicio_matricula";` — the exact same union. The `topology-adapter.ts:23-24` re-exports it from `@cadeia/chain-topology`. Redefining inline in `builder.ts` creates **two parallel definitions of the same union** that can drift.
+
+**Fix:** In `builder.ts`:
+```typescript
+import type { LancamentoTipo } from "@cadeia/chain-topology";
+// ...
+export interface ChainData {
+  // ...
+  lancamentos: Array<{
+    id: string;
+    documentoId: string;
+    tipo: LancamentoTipo; // imported, not redefined
+  }>;
+  // ...
+}
+```
+
+The vitest alias `"@cadeia/chain-topology": path.resolve(__dirname, "../../scripts/seed")` is already configured (vitest.config.ts:12), so the import resolves in tests.
+
+#### MUST-FIX #2: `OrigemTipo` source-inference must match `topology-adapter.ts` coercion for `averbacao`
+
+**Plan location:** S-2 scope, the line `data.tipoOrigem = inferred from source document's tipo if not provided`, and S-4 "Edge mapping (3 cases)".
+
+**Issue:** The plan's inference rule says "matricula → matricula, transcrição → transcrição" but `DocumentoTipo` is a 3-value union: `"matricula" | "transcricao" | "averbacao"`. If source `DocumentoTipo === "averbacao"`, the plan is silent. The existing `topology-adapter.ts:149-151` handles this with `doc?.tipo === "transcricao" ? "transcricao" : "matricula"` — meaning **averbacao coerces to "matricula"** (the "everything-not-transcricao is matricula" convention).
+
+**Fix:** In `buildGraph` and tests, follow `topology-adapter.ts`:
+```typescript
+function inferOrigemTipo(sourceDocTipo: DocumentoTipo): OrigemTipo {
+  return sourceDocTipo === "transcricao" ? "transcricao" : "matricula";
+}
+```
+
+Add a S-4 test case: "Edge from averbacao source (no tipoOrigem provided) → inferred as 'matricula'".
+
+#### MUST-FIX #3: Pre-flight existing-file coverage at 100% threshold before raising
+
+**Plan location:** S-1 acceptance + Risk #2.
+
+**Issue:** S-1 raises the global threshold from 80 → 100 in one step. If any existing file fails (e.g., `GraphPreview.tsx` — React component, no direct tests; `index.ts` — barrel; `topology-adapter.ts` — has tests but at 138 lines may have uncovered branches), the build breaks.
+
+**Fix:** S-1 acceptance must include this **diagnostic step**:
+```bash
+# Run BEFORE raising the threshold to discover what needs attention
+pnpm test:unit:coverage 2>&1 | tee /tmp/coverage-baseline.log
+# Read /tmp/coverage-baseline.log and identify any files < 100%.
+# Either add the missing tests, OR add the file to vitest.config.ts exclude.
+```
+Then S-1's "raise threshold to 100" step is conditional on baseline being clean. **Do not raise globally if baseline is not clean — prefer per-file thresholds via `coverage.thresholds.perFile` (Vitest 3.x feature) or selective `include` in coverage config.**
+
+#### MUST-FIX #4: Plan S-6 has a quoting bug in the grep command
+
+**Plan location:** S-6 acceptance, line 320.
+
+**Issue:**
+```
+grep -E "buildGraph|generateMockGraph packages/web/src/graph/index.ts
+```
+The grep is malformed — missing a closing `"` and missing the file path separator. As written, grep would look for the literal string `generateMockGraph packages/web/src/graph/index.ts` in stdin.
+
+**Fix:** Use a working command:
+```bash
+grep -E "buildGraph|generateMockGraph" packages/web/src/graph/index.ts
+```
+
+### NICE (nice-to-have, apply if cheap)
+
+#### NICE #1: Add one explicit test for `ChainData` with no `lancamentos[]` (origens reference no lancamentos)
+
+This is an edge case the plan doesn't enumerate in S-4. If a user passes `ChainData` with `origens` whose `lancamentoId` doesn't exist in `lancamentos[]`, `buildGraph` should throw. Add a negative test in S-4.
+
+#### NICE #2: `vitest.config.ts` should add `src/graph/builder.ts` and `src/graph/mock.ts` to `coverage.include` (or remove nothing, just verify they are in the default glob)
+
+Default `coverage.include` for Vitest is `["**"]` — both files will be covered. But explicit `include: ["src/graph/**"]` for the 100% gate is more defensive. Skip unless coverage reports miss the new files.
+
+### DISAGREE
+
+None blocking. I accept the planner's "raise global to 100%" decision with MUST-FIX #3's pre-flight caveat. The "ChainData object vs multiple args" choice is well-reasoned. The "synthetic fim = inconclusa" choice is consistent with T-200.
+
+### Summary
+
+Plan is **executable after the 4 MUST-FIX items are applied during S-1 and S-2**. Once those are addressed, dispatch to claude-glm with a clear pointer to this section. The implementer should read both the plan and this verdict before starting.
+
+## Acceptance gate summary
+
+
+
+The 4 acceptance bullets from the spec, with exact commands:
+
+1. **`buildGraph()` produces valid `{ nodes, edges }` from typed input**
+   - Command: `pnpm test:unit builder.test.test`
+   - Pass: All 11+ builder test cases pass; coverage 100% on `builder.ts`
+
+2. **`applyLayout()` produces non-overlapping positions for graphs up to 100 nodes**
+   - Command: `pnpm test:unit layoutGraph.test.ts`
+   - Pass: All 7 existing layout tests pass (already shipped in PR #28+#29)
+   - Note: This acceptance is already satisfied; spec line 108 "BFS layout" is stale
+
+3. **`generateMockGraph('linear'|'branching'|'merge')` returns deterministic output**
+   - Command: `pnpm test:unit mock.test.ts`
+   - Pass: All 8+ mock test cases pass; determinism tests verify byte-identical output; coverage 100% on `mock.ts`
+
+4. **100% unit test coverage on pure functions**
+   - Command: `pnpm test:unit:coverage`
+   - Pass: Coverage report shows 100% on `builder.ts` and `mock.ts`; overall project ≥ 100% (after threshold raise in S-1)
+
+**Final verification command (runs all):**
+```bash
+pnpm typecheck && pnpm lint && pnpm test:unit:coverage
+```
+All must exit 0 for T-501 to be complete.

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -99,7 +99,7 @@ Phase 0: Decisions ──┐
 - **Blocks:** T-501
 
 ### T-501 — Graph data layer (types + mock builder)
-- **Status:** 🔧 in-progress (partial: PR #28+#29 landed the types + validate + layout + fixture; mock builders + 100% coverage still pending)
+- **Status:** 🔧 ready for review (builder + generateMockGraph + 100% coverage on new files; awaiting PR)
 - **Worktree branch:** `feat/xyflow-graph-data`
 - **Files:** `packages/web/src/lib/graph/`
 - **Description:** Pure TypeScript library that builds `{ nodes, edges }` from domain data:
@@ -227,7 +227,7 @@ Phase 0: Decisions ──┐
 | T-100 | ✅ done | #26 |
 | T-101 | ✅ done | #25 |
 | **T-500** | 📋 **ready** | — |
-| T-501 | 🔧 in-progress (partial: PR #28+#29) | — |
+| T-501 | 🔧 ready for review (builder + generateMockGraph + 100% coverage) | — |
 | T-502 | 🔧 in-progress (partial: PR #28+#29) | — |
 | T-503 | blocked (T-502, T-202) | — |
 | T-200 | 📋 ready | — |

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "pnpm test:unit && pnpm test:e2e",
     "test:unit": "vitest run",
+    "test:unit:coverage": "vitest run --coverage",
     "test:e2e": "playwright test --config ../../playwright.config.ts",
     "deploy": "wrangler pages deploy dist"
   },
@@ -35,6 +36,7 @@
     "playwright": "^1.57.0",
     "typescript": "^5.9.3",
     "vite": "^7.3.1",
-    "vitest": "^4.0.17"
+    "vitest": "^4.0.17",
+    "@vitest/coverage-v8": "^4.1.8"
   }
 }

--- a/packages/web/src/graph/README.md
+++ b/packages/web/src/graph/README.md
@@ -18,6 +18,8 @@ graph JSON  →  validateGraph  →  layoutGraph  →  toReactFlow  →  <ReactF
 | `layoutGraph.ts` | Deterministic dagre LR layout. Trust contract: caller has already validated. | `GraphJson` → `LayoutedGraph` |
 | `toReactFlow.ts` | Adapts the layouted graph into React Flow's `Node`/`Edge` shapes. | `LayoutedGraph` → `{ nodes, edges }` |
 | `GraphPreview.tsx` | The React Flow renderer. Memoizes the pipeline on the input ref. | `unknown` → rendered React Flow |
+| `builder.ts` | Builds `{ nodes, edges }` from typed domain input (ChainData). | `ChainData` → `GraphJson` |
+| `mock.ts` | Deterministic mock generators for development. | `MockShape` → `GraphJson` |
 | `fixtures/basic-graph.json` | Canonical 3-node / 2-edge fixture (source → process → output). | — |
 | `index.ts` | Public barrel. | — |
 
@@ -50,3 +52,37 @@ shape will throw at the first render — that's intentional.
 graph, radial) is a new function with the same signature, then a small
 switch in `GraphPreview` if both are exposed. Don't try to make `layoutGraph`
 itself pluggable — the contract is "dagre LR for now".
+
+## Building graphs from domain data
+
+`buildGraph()` takes a typed `ChainData` input and produces a `GraphJson`:
+
+```typescript
+import { buildGraph } from "@cadeia/web/src/graph";
+
+const graph = buildGraph({
+  documentos: [
+    { id: "doc-1", numero: "M123", tipo: "matricula", cartorioId: "cartorio-1", data: "2024-01-15" }
+  ],
+  lancamentos: [
+    { id: "lanc-1", documentoId: "doc-1", tipo: "registro" }
+  ],
+  origens: []
+});
+```
+
+It maps `documentos` → nodes, `origens` → edges, and adds synthetic `fim-cadeia` leaves for documents with no outgoing origens.
+
+## Mock data for development
+
+`generateMockGraph()` produces deterministic mock graphs in three shapes:
+
+```typescript
+import { generateMockGraph } from "@cadeia/web/src/graph";
+
+const linear = generateMockGraph("linear");   // 6 nodes, 5 edges
+const branching = generateMockGraph("branching"); // 6 nodes, 5 edges
+const merge = generateMockGraph("merge");     // 4 nodes, 3 edges
+```
+
+Same shape → byte-identical output. No PRNG.

--- a/packages/web/src/graph/builder.test.ts
+++ b/packages/web/src/graph/builder.test.ts
@@ -1,0 +1,499 @@
+import { describe, it, expect } from "vitest";
+import { buildGraph, type ChainData } from "./builder";
+import type { LancamentoTipo } from "@cadeia/chain-topology";
+
+describe("buildGraph", () => {
+  // --- Happy paths (3 cases) ---
+
+  it("single documento with no origens → adds synthetic fim-cadeia leaf", () => {
+    const chainData: ChainData = {
+      documentos: [
+        {
+          id: "1",
+          numero: "M1",
+          tipo: "matricula",
+          cartorioId: "cartorio-1",
+          data: "2024-01-01",
+        },
+      ],
+      lancamentos: [],
+      origens: [],
+    };
+
+    const result = buildGraph(chainData);
+
+    expect(result.nodes).toHaveLength(2);
+    expect(result.nodes[0].id).toBe("doc-1");
+    expect(result.nodes[0].type).toBe("documento");
+    expect(result.nodes[1].id).toBe("fim-1");
+    expect(result.nodes[1].type).toBe("fimCadeia");
+    const fimNode = result.nodes[1];
+    if (fimNode.type === "fimCadeia") {
+      expect(fimNode.data.classificacao).toBe("inconclusa");
+    }
+
+    expect(result.edges).toHaveLength(1);
+    expect(result.edges[0].source).toBe("doc-1");
+    expect(result.edges[0].target).toBe("fim-1");
+    expect(result.edges[0].data?.tipoOrigem).toBe("fim_cadeia");
+  });
+
+  it("linear chain of 3 documentos → correct edges + synthetic leaf on last", () => {
+    const chainData: ChainData = {
+      documentos: [
+        {
+          id: "1",
+          numero: "M1",
+          tipo: "matricula",
+          cartorioId: "cartorio-1",
+          data: "2024-01-01",
+        },
+        {
+          id: "2",
+          numero: "M2",
+          tipo: "matricula",
+          cartorioId: "cartorio-1",
+          data: "2024-01-02",
+        },
+        {
+          id: "3",
+          numero: "M3",
+          tipo: "matricula",
+          cartorioId: "cartorio-1",
+          data: "2024-01-03",
+        },
+      ],
+      lancamentos: [
+        { id: "lanc-1", documentoId: "2", tipo: "registro" as LancamentoTipo },
+        { id: "lanc-2", documentoId: "3", tipo: "registro" as LancamentoTipo },
+      ],
+      origens: [
+        { id: "orig-1", lancamentoId: "lanc-1", documentoId: "1" },
+        { id: "orig-2", lancamentoId: "lanc-2", documentoId: "2" },
+      ],
+    };
+
+    const result = buildGraph(chainData);
+
+    expect(result.nodes).toHaveLength(4);
+    expect(result.nodes.map((n) => n.id)).toEqual(["doc-1", "doc-2", "doc-3", "fim-3"]);
+
+    expect(result.edges).toHaveLength(3);
+    expect(result.edges[0].source).toBe("doc-1");
+    expect(result.edges[0].target).toBe("doc-2");
+    expect(result.edges[1].source).toBe("doc-2");
+    expect(result.edges[1].target).toBe("doc-3");
+    expect(result.edges[2].source).toBe("doc-3");
+    expect(result.edges[2].target).toBe("fim-3");
+  });
+
+  it("branching (1→2) → both branches get synthetic leaves", () => {
+    const chainData: ChainData = {
+      documentos: [
+        {
+          id: "1",
+          numero: "M1",
+          tipo: "matricula",
+          cartorioId: "cartorio-1",
+          data: "2024-01-01",
+        },
+        {
+          id: "2",
+          numero: "M2",
+          tipo: "matricula",
+          cartorioId: "cartorio-1",
+          data: "2024-01-02",
+        },
+        {
+          id: "3",
+          numero: "M3",
+          tipo: "matricula",
+          cartorioId: "cartorio-1",
+          data: "2024-01-03",
+        },
+      ],
+      lancamentos: [
+        { id: "lanc-1", documentoId: "2", tipo: "registro" as LancamentoTipo },
+        { id: "lanc-2", documentoId: "3", tipo: "registro" as LancamentoTipo },
+      ],
+      origens: [
+        { id: "orig-1", lancamentoId: "lanc-1", documentoId: "1" },
+        { id: "orig-2", lancamentoId: "lanc-2", documentoId: "1" },
+      ],
+    };
+
+    const result = buildGraph(chainData);
+
+    expect(result.nodes).toHaveLength(5);
+    expect(result.nodes.map((n) => n.id)).toEqual([
+      "doc-1",
+      "doc-2",
+      "doc-3",
+      "fim-2",
+      "fim-3",
+    ]);
+
+    expect(result.edges).toHaveLength(4);
+    expect(result.edges[0].source).toBe("doc-1");
+    expect(result.edges[0].target).toBe("doc-2");
+    expect(result.edges[1].source).toBe("doc-1");
+    expect(result.edges[1].target).toBe("doc-3");
+    expect(result.edges[2].source).toBe("doc-2");
+    expect(result.edges[2].target).toBe("fim-2");
+    expect(result.edges[3].source).toBe("doc-3");
+    expect(result.edges[3].target).toBe("fim-3");
+  });
+
+  // --- Edge mapping (3 cases + MUST-FIX #2) ---
+
+  it("edge with tipoOrigem provided → uses provided value", () => {
+    const chainData: ChainData = {
+      documentos: [
+        {
+          id: "1",
+          numero: "M1",
+          tipo: "matricula",
+          cartorioId: "cartorio-1",
+          data: "2024-01-01",
+        },
+        {
+          id: "2",
+          numero: "M2",
+          tipo: "matricula",
+          cartorioId: "cartorio-1",
+          data: "2024-01-02",
+        },
+      ],
+      lancamentos: [
+        { id: "lanc-1", documentoId: "2", tipo: "registro" as LancamentoTipo },
+      ],
+      origens: [
+        {
+          id: "orig-1",
+          lancamentoId: "lanc-1",
+          documentoId: "1",
+          tipoOrigem: "transcricao",
+        },
+      ],
+    };
+
+    const result = buildGraph(chainData);
+
+    expect(result.edges).toHaveLength(2);
+    expect(result.edges[0].data?.tipoOrigem).toBe("transcricao");
+  });
+
+  it("edge without tipoOrigem from matricula source → infers as matricula", () => {
+    const chainData: ChainData = {
+      documentos: [
+        {
+          id: "1",
+          numero: "M1",
+          tipo: "matricula",
+          cartorioId: "cartorio-1",
+          data: "2024-01-01",
+        },
+        {
+          id: "2",
+          numero: "M2",
+          tipo: "matricula",
+          cartorioId: "cartorio-1",
+          data: "2024-01-02",
+        },
+      ],
+      lancamentos: [
+        { id: "lanc-1", documentoId: "2", tipo: "registro" as LancamentoTipo },
+      ],
+      origens: [{ id: "orig-1", lancamentoId: "lanc-1", documentoId: "1" }],
+    };
+
+    const result = buildGraph(chainData);
+
+    expect(result.edges[0].data?.tipoOrigem).toBe("matricula");
+  });
+
+  it("edge without tipoOrigem from transcricao source → infers as transcricao", () => {
+    const chainData: ChainData = {
+      documentos: [
+        {
+          id: "1",
+          numero: "T1",
+          tipo: "transcricao",
+          cartorioId: "cartorio-1",
+          data: "2024-01-01",
+        },
+        {
+          id: "2",
+          numero: "M2",
+          tipo: "matricula",
+          cartorioId: "cartorio-1",
+          data: "2024-01-02",
+        },
+      ],
+      lancamentos: [
+        { id: "lanc-1", documentoId: "2", tipo: "registro" as LancamentoTipo },
+      ],
+      origens: [{ id: "orig-1", lancamentoId: "lanc-1", documentoId: "1" }],
+    };
+
+    const result = buildGraph(chainData);
+
+    expect(result.edges[0].data?.tipoOrigem).toBe("transcricao");
+  });
+
+  it("MUST-FIX #2: edge from averbacao source (no tipoOrigem) → coerces to matricula", () => {
+    const chainData: ChainData = {
+      documentos: [
+        {
+          id: "1",
+          numero: "A1",
+          tipo: "averbacao",
+          cartorioId: "cartorio-1",
+          data: "2024-01-01",
+        },
+        {
+          id: "2",
+          numero: "M2",
+          tipo: "matricula",
+          cartorioId: "cartorio-1",
+          data: "2024-01-02",
+        },
+      ],
+      lancamentos: [
+        { id: "lanc-1", documentoId: "2", tipo: "registro" as LancamentoTipo },
+      ],
+      origens: [{ id: "orig-1", lancamentoId: "lanc-1", documentoId: "1" }],
+    };
+
+    const result = buildGraph(chainData);
+
+    expect(result.edges[0].data?.tipoOrigem).toBe("matricula");
+  });
+
+  it("multiple edges from same source documento → all edges correct", () => {
+    const chainData: ChainData = {
+      documentos: [
+        {
+          id: "1",
+          numero: "M1",
+          tipo: "matricula",
+          cartorioId: "cartorio-1",
+          data: "2024-01-01",
+        },
+        {
+          id: "2",
+          numero: "M2",
+          tipo: "matricula",
+          cartorioId: "cartorio-1",
+          data: "2024-01-02",
+        },
+        {
+          id: "3",
+          numero: "M3",
+          tipo: "matricula",
+          cartorioId: "cartorio-1",
+          data: "2024-01-03",
+        },
+      ],
+      lancamentos: [
+        { id: "lanc-1", documentoId: "2", tipo: "registro" as LancamentoTipo },
+        { id: "lanc-2", documentoId: "3", tipo: "registro" as LancamentoTipo },
+      ],
+      origens: [
+        { id: "orig-1", lancamentoId: "lanc-1", documentoId: "1" },
+        { id: "orig-2", lancamentoId: "lanc-2", documentoId: "1" },
+      ],
+    };
+
+    const result = buildGraph(chainData);
+
+    expect(result.edges).toHaveLength(4);
+    expect(result.edges[0].source).toBe("doc-1");
+    expect(result.edges[0].target).toBe("doc-2");
+    expect(result.edges[1].source).toBe("doc-1");
+    expect(result.edges[1].target).toBe("doc-3");
+  });
+
+  // --- ID prefix enforcement (2 cases) ---
+
+  it("documento ID without doc- prefix → adds it automatically", () => {
+    const chainData: ChainData = {
+      documentos: [
+        {
+          id: "raw-id-123",
+          numero: "M123",
+          tipo: "matricula",
+          cartorioId: "cartorio-1",
+          data: "2024-01-01",
+        },
+      ],
+      lancamentos: [],
+      origens: [],
+    };
+
+    const result = buildGraph(chainData);
+
+    expect(result.nodes[0].id).toBe("doc-raw-id-123");
+    expect(result.edges[0].source).toBe("doc-raw-id-123");
+  });
+
+  it("documento ID with doc- prefix → keeps it unchanged", () => {
+    const chainData: ChainData = {
+      documentos: [
+        {
+          id: "doc-1",
+          numero: "M1",
+          tipo: "matricula",
+          cartorioId: "cartorio-1",
+          data: "2024-01-01",
+        },
+      ],
+      lancamentos: [],
+      origens: [],
+    };
+
+    const result = buildGraph(chainData);
+
+    expect(result.nodes[0].id).toBe("doc-1");
+  });
+
+  it("synthetic fim node ID → has fim- prefix", () => {
+    const chainData: ChainData = {
+      documentos: [
+        {
+          id: "abc-123",
+          numero: "M1",
+          tipo: "matricula",
+          cartorioId: "cartorio-1",
+          data: "2024-01-01",
+        },
+      ],
+      lancamentos: [],
+      origens: [],
+    };
+
+    const result = buildGraph(chainData);
+
+    expect(result.nodes[1].id).toBe("fim-abc-123");
+    expect(result.edges[0].target).toBe("fim-abc-123");
+  });
+
+  // --- Validation integration (2 cases) ---
+
+  it("calls validateGraph() internally → returns valid GraphJson", () => {
+    const chainData: ChainData = {
+      documentos: [
+        {
+          id: "1",
+          numero: "M1",
+          tipo: "matricula",
+          cartorioId: "cartorio-1",
+          data: "2024-01-01",
+        },
+      ],
+      lancamentos: [],
+      origens: [],
+    };
+
+    const result = buildGraph(chainData);
+
+    expect(result.nodes).toBeDefined();
+    expect(result.edges).toBeDefined();
+    expect(result.nodes).toHaveLength(2);
+    expect(result.edges).toHaveLength(1);
+  });
+
+  it("invalid input (origem references non-existent lancamento) → throws", () => {
+    const chainData: ChainData = {
+      documentos: [
+        {
+          id: "1",
+          numero: "M1",
+          tipo: "matricula",
+          cartorioId: "cartorio-1",
+          data: "2024-01-01",
+        },
+      ],
+      lancamentos: [],
+      origens: [{ id: "orig-1", lancamentoId: "nonexistent", documentoId: "1" }],
+    };
+
+    expect(() => buildGraph(chainData)).toThrow(
+      /Origem orig-1 references non-existent lancamento: nonexistent/
+    );
+  });
+
+  it("invalid input (origem references non-existent documento) → throws", () => {
+    const chainData: ChainData = {
+      documentos: [
+        {
+          id: "1",
+          numero: "M1",
+          tipo: "matricula",
+          cartorioId: "cartorio-1",
+          data: "2024-01-01",
+        },
+      ],
+      lancamentos: [
+        { id: "lanc-1", documentoId: "1", tipo: "registro" as LancamentoTipo },
+      ],
+      origens: [
+        { id: "orig-1", lancamentoId: "lanc-1", documentoId: "nonexistent" }
+      ],
+    };
+
+    expect(() => buildGraph(chainData)).toThrow(
+      /Origem orig-1 references non-existent documento: nonexistent/
+    );
+  });
+
+  it("NICE #1: ChainData with lancamento referenced by origem but missing documento → throws", () => {
+    const chainData: ChainData = {
+      documentos: [
+        {
+          id: "1",
+          numero: "M1",
+          tipo: "matricula",
+          cartorioId: "cartorio-1",
+          data: "2024-01-01",
+        },
+      ],
+      lancamentos: [
+        {
+          id: "lanc-1",
+          documentoId: "nonexistent-doc",
+          tipo: "registro" as LancamentoTipo,
+        },
+      ],
+      origens: [{ id: "orig-1", lancamentoId: "lanc-1", documentoId: "1" }],
+    };
+
+    expect(() => buildGraph(chainData)).toThrow(
+      /Lancamento lanc-1 references non-existent documento: nonexistent-doc/
+    );
+  });
+
+  // --- Synthetic leaf classification (1 case) ---
+
+  it("synthetic fim-cadeia nodes have classificacao: inconclusa", () => {
+    const chainData: ChainData = {
+      documentos: [
+        {
+          id: "1",
+          numero: "M1",
+          tipo: "matricula",
+          cartorioId: "cartorio-1",
+          data: "2024-01-01",
+        },
+      ],
+      lancamentos: [],
+      origens: [],
+    };
+
+    const result = buildGraph(chainData);
+
+    const fimNode = result.nodes.find((n) => n.type === "fimCadeia");
+    expect(fimNode).toBeDefined();
+    expect(fimNode?.data.classificacao).toBe("inconclusa");
+  });
+});

--- a/packages/web/src/graph/builder.ts
+++ b/packages/web/src/graph/builder.ts
@@ -1,0 +1,139 @@
+import type { LancamentoTipo } from "@cadeia/chain-topology";
+import type { DocumentoTipo, GraphEdge, GraphJson, GraphNode, OrigemTipo } from "./types";
+import { validateGraph } from "./validateGraph";
+
+/**
+ * Minimal typed domain input for `buildGraph`. This is a simplified shape
+ * compared to `TopologyGraph` — it's designed for API responses or direct
+ * user-provided data, not the rich seed-script output.
+ */
+export interface ChainData {
+  documentos: Array<{
+    id: string;
+    numero: string;
+    tipo: DocumentoTipo;
+    cartorioId: string;
+    data: string;
+  }>;
+  lancamentos: Array<{
+    id: string;
+    documentoId: string;
+    tipo: LancamentoTipo;
+  }>;
+  origens: Array<{
+    id: string;
+    lancamentoId: string;
+    documentoId: string;
+    tipoOrigem?: OrigemTipo;
+  }>;
+}
+
+/**
+ * Builds a `{ nodes, edges }` graph from typed domain input.
+ *
+ * - Maps documentos → nodes with `type: "documento"`
+ * - Maps origens → edges from source documento → target documento
+ * - Adds synthetic `fim-cadeia` leaves for documentos with no outgoing origens
+ * - Calls `validateGraph()` before returning (defense in depth)
+ *
+ * Throws on invalid input (missing documento/lancamento references, cycles, etc.).
+ */
+export function buildGraph(chainData: ChainData): GraphJson {
+  const lancamentosById = new Map(chainData.lancamentos.map((l) => [l.id, l]));
+  const documentosById = new Map(chainData.documentos.map((d) => [d.id, d]));
+
+  const nodes: GraphNode[] = chainData.documentos.map((doc) => {
+    const id = ensureDocPrefix(doc.id);
+    return {
+      id,
+      label: `Documento ${doc.numero}`,
+      type: "documento",
+      data: {
+        numero: doc.numero,
+        tipo: doc.tipo,
+        cartorioId: doc.cartorioId,
+        data: doc.data,
+      },
+    };
+  });
+
+  const edges: GraphEdge[] = [];
+
+  // Track which documentos are sources of at least one origem
+  const documentosAsSource = new Set<string>();
+
+  for (const origem of chainData.origens) {
+    const lancamento = lancamentosById.get(origem.lancamentoId);
+    if (!lancamento) {
+      throw new Error(`Origem ${origem.id} references non-existent lancamento: ${origem.lancamentoId}`);
+    }
+
+    const targetDoc = documentosById.get(lancamento.documentoId);
+    if (!targetDoc) {
+      throw new Error(
+        `Lancamento ${lancamento.id} references non-existent documento: ${lancamento.documentoId}`
+      );
+    }
+
+    const sourceDoc = documentosById.get(origem.documentoId);
+    if (!sourceDoc) {
+      throw new Error(`Origem ${origem.id} references non-existent documento: ${origem.documentoId}`);
+    }
+
+    const sourceId = ensureDocPrefix(origem.documentoId);
+    const targetId = ensureDocPrefix(lancamento.documentoId);
+
+    documentosAsSource.add(sourceId);
+
+    edges.push({
+      id: origem.id,
+      source: sourceId,
+      target: targetId,
+      data: {
+        tipoOrigem:
+          origem.tipoOrigem ?? inferOrigemTipo(sourceDoc.tipo),
+      },
+    });
+  }
+
+  // Add synthetic fim-cadeia leaves for documentos with no outgoing origens
+  for (const doc of chainData.documentos) {
+    const docId = ensureDocPrefix(doc.id);
+    if (!documentosAsSource.has(docId)) {
+      const fimId = `fim-${doc.id}`;
+      nodes.push({
+        id: fimId,
+        label: "Fim de cadeia",
+        type: "fimCadeia",
+        data: { classificacao: "inconclusa" },
+      });
+      edges.push({
+        id: `synthetic-${docId}->${fimId}`,
+        source: docId,
+        target: fimId,
+        data: { tipoOrigem: "fim_cadeia" },
+      });
+    }
+  }
+
+  return validateGraph({ nodes, edges });
+}
+
+/**
+ * Ensures a documento ID has the `doc-` prefix.
+ * If it already has the prefix, returns it unchanged.
+ */
+function ensureDocPrefix(id: string): string {
+  return id.startsWith("doc-") ? id : `doc-${id}`;
+}
+
+/**
+ * Infers `OrigemTipo` from a documento's tipo.
+ *
+ * Follows the convention from `topology-adapter.ts`:
+ * - transcricao → "transcricao"
+ * - matricula or averbacao → "matricula" (averbacao coerces to matricula)
+ */
+function inferOrigemTipo(sourceDocTipo: DocumentoTipo): OrigemTipo {
+  return sourceDocTipo === "transcricao" ? "transcricao" : "matricula";
+}

--- a/packages/web/src/graph/builder.ts
+++ b/packages/web/src/graph/builder.ts
@@ -133,6 +133,7 @@ function ensureDocPrefix(id: string): string {
  * Follows the convention from `topology-adapter.ts`:
  * - transcricao → "transcricao"
  * - matricula or averbacao → "matricula" (averbacao coerces to matricula)
+ * TODO: Revisit this coercion — averbacao may need distinct handling
  */
 function inferOrigemTipo(sourceDocTipo: DocumentoTipo): OrigemTipo {
   return sourceDocTipo === "transcricao" ? "transcricao" : "matricula";

--- a/packages/web/src/graph/index.ts
+++ b/packages/web/src/graph/index.ts
@@ -5,6 +5,8 @@ export { toReactFlow } from "./toReactFlow";
 export { topologyToGraphJson } from "./topology-adapter";
 export { generateChainTopology } from "./topology-adapter";
 export { assertTopologyInvariants, TopologyInvariantError } from "./topology-adapter";
+export { buildGraph, type ChainData } from "./builder";
+export { generateMockGraph, type MockShape } from "./mock";
 export {
   DocumentoNode,
   type DocumentoNodeData,

--- a/packages/web/src/graph/mock.test.ts
+++ b/packages/web/src/graph/mock.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from "vitest";
+import { generateMockGraph } from "./mock";
+import { validateGraph } from "./validateGraph";
+
+describe("generateMockGraph", () => {
+  // --- Determinism (3 cases) ---
+
+  it("linear shape → byte-identical output across calls", () => {
+    const first = generateMockGraph("linear");
+    const second = generateMockGraph("linear");
+
+    expect(first).toEqual(second);
+    expect(JSON.stringify(first)).toBe(JSON.stringify(second));
+  });
+
+  it("branching shape → byte-identical output across calls", () => {
+    const first = generateMockGraph("branching");
+    const second = generateMockGraph("branching");
+
+    expect(first).toEqual(second);
+    expect(JSON.stringify(first)).toBe(JSON.stringify(second));
+  });
+
+  it("merge shape → byte-identical output across calls", () => {
+    const first = generateMockGraph("merge");
+    const second = generateMockGraph("merge");
+
+    expect(first).toEqual(second);
+    expect(JSON.stringify(first)).toBe(JSON.stringify(second));
+  });
+
+  // --- Shape verification (3 cases) ---
+
+  it("linear shape → 6 nodes, 5 edges", () => {
+    const graph = generateMockGraph("linear");
+
+    expect(graph.nodes).toHaveLength(6);
+    expect(graph.edges).toHaveLength(5);
+
+    // 5 documento nodes + 1 synthetic fim
+    const docNodes = graph.nodes.filter((n) => n.type === "documento");
+    const fimNodes = graph.nodes.filter((n) => n.type === "fimCadeia");
+    expect(docNodes).toHaveLength(5);
+    expect(fimNodes).toHaveLength(1);
+
+    // 4 doc→doc edges + 1 doc→fim edge
+    const docToDocEdges = graph.edges.filter(
+      (e) =>
+        graph.nodes.find((n) => n.id === e.source)?.type === "documento" &&
+        graph.nodes.find((n) => n.id === e.target)?.type === "documento"
+    );
+    const docToFimEdges = graph.edges.filter(
+      (e) =>
+        graph.nodes.find((n) => n.id === e.source)?.type === "documento" &&
+        graph.nodes.find((n) => n.id === e.target)?.type === "fimCadeia"
+    );
+    expect(docToDocEdges).toHaveLength(4);
+    expect(docToFimEdges).toHaveLength(1);
+  });
+
+  it("branching shape → 6 nodes, 5 edges", () => {
+    const graph = generateMockGraph("branching");
+
+    expect(graph.nodes).toHaveLength(6);
+    expect(graph.edges).toHaveLength(5);
+
+    // 4 documento nodes + 2 synthetic fims
+    const docNodes = graph.nodes.filter((n) => n.type === "documento");
+    const fimNodes = graph.nodes.filter((n) => n.type === "fimCadeia");
+    expect(docNodes).toHaveLength(4);
+    expect(fimNodes).toHaveLength(2);
+
+    // 3 doc→doc edges + 2 doc→fim edges
+    const docToDocEdges = graph.edges.filter(
+      (e) =>
+        graph.nodes.find((n) => n.id === e.source)?.type === "documento" &&
+        graph.nodes.find((n) => n.id === e.target)?.type === "documento"
+    );
+    const docToFimEdges = graph.edges.filter(
+      (e) =>
+        graph.nodes.find((n) => n.id === e.source)?.type === "documento" &&
+        graph.nodes.find((n) => n.id === e.target)?.type === "fimCadeia"
+    );
+    expect(docToDocEdges).toHaveLength(3);
+    expect(docToFimEdges).toHaveLength(2);
+  });
+
+  it("merge shape → 4 nodes, 3 edges", () => {
+    const graph = generateMockGraph("merge");
+
+    expect(graph.nodes).toHaveLength(4);
+    expect(graph.edges).toHaveLength(3);
+
+    // 3 documento nodes + 1 synthetic fim
+    const docNodes = graph.nodes.filter((n) => n.type === "documento");
+    const fimNodes = graph.nodes.filter((n) => n.type === "fimCadeia");
+    expect(docNodes).toHaveLength(3);
+    expect(fimNodes).toHaveLength(1);
+
+    // 2 doc→doc edges + 1 doc→fim edge
+    const docToDocEdges = graph.edges.filter(
+      (e) =>
+        graph.nodes.find((n) => n.id === e.source)?.type === "documento" &&
+        graph.nodes.find((n) => n.id === e.target)?.type === "documento"
+    );
+    const docToFimEdges = graph.edges.filter(
+      (e) =>
+        graph.nodes.find((n) => n.id === e.source)?.type === "documento" &&
+        graph.nodes.find((n) => n.id === e.target)?.type === "fimCadeia"
+    );
+    expect(docToDocEdges).toHaveLength(2);
+    expect(docToFimEdges).toHaveLength(1);
+  });
+
+  // --- Node data completeness (1 case) ---
+
+  it("all nodes have required data fields", () => {
+    const linear = generateMockGraph("linear");
+    const branching = generateMockGraph("branching");
+    const merge = generateMockGraph("merge");
+
+    [linear, branching, merge].forEach((graph) => {
+      // Every documento node has numero, tipo, cartorioId, data
+      const docNodes = graph.nodes.filter((n) => n.type === "documento");
+      docNodes.forEach((node) => {
+        if (node.type === "documento") {
+          expect(node.data.numero).toBeDefined();
+          expect(node.data.tipo).toBeDefined();
+          expect(node.data.cartorioId).toBeDefined();
+          expect(node.data.data).toBeDefined();
+        }
+      });
+
+      // Every fimCadeia node has classificacao
+      const fimNodes = graph.nodes.filter((n) => n.type === "fimCadeia");
+      fimNodes.forEach((node) => {
+        if (node.type === "fimCadeia") {
+          expect(node.data.classificacao).toBeDefined();
+        }
+      });
+    });
+  });
+
+  // --- Validation integration (1 case) ---
+
+  it("output passes validateGraph() for all shapes", () => {
+    const linear = generateMockGraph("linear");
+    const branching = generateMockGraph("branching");
+    const merge = generateMockGraph("merge");
+
+    expect(() => validateGraph(linear)).not.toThrow();
+    expect(() => validateGraph(branching)).not.toThrow();
+    expect(() => validateGraph(merge)).not.toThrow();
+  });
+});

--- a/packages/web/src/graph/mock.ts
+++ b/packages/web/src/graph/mock.ts
@@ -1,0 +1,172 @@
+import type { GraphJson } from "./types";
+import { validateGraph } from "./validateGraph";
+
+/**
+ * Shape parameter for `generateMockGraph`.
+ * Determines the structure of the generated chain.
+ */
+export type MockShape = "linear" | "branching" | "merge";
+
+/**
+ * Generates a deterministic mock graph for development.
+ *
+ * - **Linear**: 5 documentos in a chain with 1 synthetic fim leaf
+ * - **Branching**: 1 root → 2 branches → 2 separate synthetic fim leaves
+ * - **Merge**: 2 sources merge into 1 target → 1 synthetic fim leaf
+ *
+ * Uses pure construction (no PRNG) — same shape → byte-identical output every time.
+ * Calls `validateGraph()` before returning (defense in depth).
+ */
+export function generateMockGraph(shape: MockShape): GraphJson {
+  if (shape === "linear") {
+    return generateLinear();
+  }
+  if (shape === "branching") {
+    return generateBranching();
+  }
+  return generateMerge();
+}
+
+function generateLinear(): GraphJson {
+  const graph: GraphJson = {
+    nodes: [
+      {
+        id: "doc-1",
+        label: "Documento M1",
+        type: "documento",
+        // TODO(T-503): real cartório lookup; placeholder until multi-cartório
+        // support lands.
+        data: { numero: "M1", tipo: "matricula", cartorioId: "cartorio-1", data: "2024-01-01" },
+      },
+      {
+        id: "doc-2",
+        label: "Documento M2",
+        type: "documento",
+        data: { numero: "M2", tipo: "matricula", cartorioId: "cartorio-1", data: "2024-01-02" },
+      },
+      {
+        id: "doc-3",
+        label: "Documento M3",
+        type: "documento",
+        data: { numero: "M3", tipo: "matricula", cartorioId: "cartorio-1", data: "2024-01-03" },
+      },
+      {
+        id: "doc-4",
+        label: "Documento M4",
+        type: "documento",
+        data: { numero: "M4", tipo: "matricula", cartorioId: "cartorio-1", data: "2024-01-04" },
+      },
+      {
+        id: "doc-5",
+        label: "Documento M5",
+        type: "documento",
+        data: { numero: "M5", tipo: "matricula", cartorioId: "cartorio-1", data: "2024-01-05" },
+      },
+      {
+        id: "fim-5",
+        label: "Fim de cadeia",
+        type: "fimCadeia",
+        data: { classificacao: "inconclusa" },
+      },
+    ],
+    edges: [
+      { id: "orig-1", source: "doc-1", target: "doc-2", data: { tipoOrigem: "matricula" } },
+      { id: "orig-2", source: "doc-2", target: "doc-3", data: { tipoOrigem: "matricula" } },
+      { id: "orig-3", source: "doc-3", target: "doc-4", data: { tipoOrigem: "matricula" } },
+      { id: "orig-4", source: "doc-4", target: "doc-5", data: { tipoOrigem: "matricula" } },
+      { id: "doc-5->fim-5", source: "doc-5", target: "fim-5", data: { tipoOrigem: "fim_cadeia" } },
+    ],
+  };
+
+  return validateGraph(graph);
+}
+
+function generateBranching(): GraphJson {
+  const graph: GraphJson = {
+    nodes: [
+      {
+        id: "doc-1",
+        label: "Documento M1",
+        type: "documento",
+        data: { numero: "M1", tipo: "matricula", cartorioId: "cartorio-1", data: "2024-01-01" },
+      },
+      {
+        id: "doc-2",
+        label: "Documento M2",
+        type: "documento",
+        data: { numero: "M2", tipo: "matricula", cartorioId: "cartorio-1", data: "2024-01-02" },
+      },
+      {
+        id: "doc-3",
+        label: "Documento T1",
+        type: "documento",
+        data: { numero: "T1", tipo: "transcricao", cartorioId: "cartorio-1", data: "2024-01-03" },
+      },
+      {
+        id: "doc-4",
+        label: "Documento M4",
+        type: "documento",
+        data: { numero: "M4", tipo: "matricula", cartorioId: "cartorio-1", data: "2024-01-04" },
+      },
+      {
+        id: "fim-3",
+        label: "Fim de cadeia",
+        type: "fimCadeia",
+        data: { classificacao: "origem_lidima" },
+      },
+      {
+        id: "fim-4",
+        label: "Fim de cadeia",
+        type: "fimCadeia",
+        data: { classificacao: "sem_origem" },
+      },
+    ],
+    edges: [
+      { id: "orig-1", source: "doc-1", target: "doc-2", data: { tipoOrigem: "matricula" } },
+      { id: "orig-2", source: "doc-2", target: "doc-3", data: { tipoOrigem: "transcricao" } },
+      { id: "orig-3", source: "doc-2", target: "doc-4", data: { tipoOrigem: "matricula" } },
+      { id: "doc-3->fim-3", source: "doc-3", target: "fim-3", data: { tipoOrigem: "fim_cadeia" } },
+      { id: "doc-4->fim-4", source: "doc-4", target: "fim-4", data: { tipoOrigem: "fim_cadeia" } },
+    ],
+  };
+
+  return validateGraph(graph);
+}
+
+function generateMerge(): GraphJson {
+  const graph: GraphJson = {
+    nodes: [
+      {
+        id: "doc-1",
+        label: "Documento M1",
+        type: "documento",
+        data: { numero: "M1", tipo: "matricula", cartorioId: "cartorio-1", data: "2024-01-01" },
+      },
+      {
+        id: "doc-2",
+        label: "Documento T1",
+        type: "documento",
+        data: { numero: "T1", tipo: "transcricao", cartorioId: "cartorio-1", data: "2024-01-02" },
+      },
+      {
+        id: "doc-3",
+        label: "Documento M3",
+        type: "documento",
+        data: { numero: "M3", tipo: "matricula", cartorioId: "cartorio-1", data: "2024-01-03" },
+      },
+      {
+        id: "fim-3",
+        label: "Fim de cadeia",
+        type: "fimCadeia",
+        data: { classificacao: "inconclusa" },
+      },
+    ],
+    edges: [
+      { id: "orig-1", source: "doc-1", target: "doc-3", data: { tipoOrigem: "matricula" } },
+      { id: "orig-2", source: "doc-2", target: "doc-3", data: { tipoOrigem: "transcricao" } },
+      { id: "doc-3->fim-3", source: "doc-3", target: "fim-3", data: { tipoOrigem: "fim_cadeia" } },
+    ],
+  };
+
+  return validateGraph(graph);
+}

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -30,8 +30,8 @@ export default defineConfig({
       functions: 80,
       branches: 80,
       statements: 80,
-      perFile: true,
       thresholds: {
+        perFile: true,
         "src/graph/builder.ts": {
           lines: 100,
           functions: 100,

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -21,10 +21,30 @@ export default defineConfig({
     coverage: {
       provider: "v8",
       reporter: ["text", "html", "lcov"],
+      // Global thresholds kept at 80% because legacy files
+      // (validateGraph.ts, topology-adapter.ts) have throw-path gaps
+      // (Pitfall #15 in .hermes/plans/T-501.md). Per-file thresholds
+      // enforce the T-501 spec gate ("100% unit test coverage on pure
+      // functions") for the new pure-function files only.
       lines: 80,
       functions: 80,
       branches: 80,
       statements: 80,
+      perFile: true,
+      thresholds: {
+        "src/graph/builder.ts": {
+          lines: 100,
+          functions: 100,
+          branches: 100,
+          statements: 100,
+        },
+        "src/graph/mock.ts": {
+          lines: 100,
+          functions: 100,
+          branches: 100,
+          statements: 100,
+        },
+      },
       exclude: ["**/e2e/**", "**/node_modules/**", "src/test/**"],
     },
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,6 +137,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^5.0.2
         version: 5.2.0(vite@7.3.5(@types/node@25.9.1)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/coverage-v8':
+        specifier: ^4.1.8
+        version: 4.1.8(vitest@4.1.8)
       jsdom:
         specifier: ^24.0.0
         version: 24.1.3


### PR DESCRIPTION
## Summary

Implements T-501 (graph data layer) on top of the types/validate/layout shipped in PR #28+#29.

### What

- `buildGraph(chainData: ChainData) → GraphJson` (`packages/web/src/graph/builder.ts`)
  - Builds `nodes` and `edges` from domain input (`documentos[]`, `lancamentos[]`, `origens[]`)
  - Imports `LancamentoTipo` from `@cadeia/chain-topology`
  - Coerces `averbacao` → `matricula` to match `topology-adapter.ts` convention
  - Adds synthetic `fim-cadeia` leaves for documentos with no outgoing origens
  - Namespace-isolated synthetic edge IDs (`synthetic-{docId}->{fimId}`)
  - Calls `validateGraph()` as defense-in-depth

- `generateMockGraph(shape: 'linear' | 'branching' | 'merge') → GraphJson` (`packages/web/src/graph/mock.ts`)
  - Three deterministic shapes for development and component testing
  - TODO(T-503) marked on `cartorioId` placeholder
  - Calls `validateGraph()` to keep mock output honest

### Tests

- `pnpm test:unit` — **101/101 pass** (16 builder + 8 mock + 77 others)
- `npx vitest run --coverage` — `builder.ts` 100/100/100/100, `mock.ts` 100/100/100/100
- 100% gate **enforced via per-file thresholds** in `packages/web/vitest.config.ts` (global threshold stays at 80% because legacy `validateGraph.ts` and `topology-adapter.ts` have throw-path gaps)

### Quality gates

- `pnpm typecheck` — clean
- `pnpm lint` — clean
- Pre-commit hooks — 4/4 pass (cached)
- Independent review (Claude Opus, 2 rounds): **APROVA 5/5** (round 1: 3/5, round 2: 5/5 after strike-1 fixes; BLOCKER #2 from round 1 rejected as false positive)

### Files

| File | Lines | Notes |
|------|-------|-------|
| `packages/web/src/graph/builder.ts` | 139 | new |
| `packages/web/src/graph/builder.test.ts` | 499 | new (16 tests) |
| `packages/web/src/graph/mock.ts` | 172 | new |
| `packages/web/src/graph/mock.test.ts` | 155 | new (8 tests) |
| `packages/web/src/graph/index.ts` | +2 | re-export |
| `packages/web/src/graph/README.md` | +36 | builder + mock usage |
| `packages/web/vitest.config.ts` | +20 | per-file thresholds |
| `packages/web/package.json` | +4 | `@vitest/coverage-v8`, `test:unit:coverage` script |
| `pnpm-lock.yaml` | +3 | lockfile |
| `docs/TASKS.md` | ±4 | T-501 status → done |

**Total: 10 files changed, 1031 insertions(+), 3 deletions(-)**

### Closes

- T-501 (graph data layer)

### Follow-ups (POST-MERGE, not blocking)

- Reconcile `DocumentoTipo` union drift between `packages/web/src/graph/types.ts` (includes `averbacao`) and `scripts/seed/chain-topology.ts` (does not)
- Cosmetic: redundant type guards in test filter callbacks