### PR TITLE
fix(graph): T-501 post-merge cleanup (cycle detection, mock tipoOrigem, vitest thresholds)

### DIFF
--- a/packages/web/src/graph/builder.test.ts
+++ b/packages/web/src/graph/builder.test.ts
@@ -144,6 +144,63 @@ describe("buildGraph", () => {
     expect(result.edges[3].target).toBe("fim-3");
   });
 
+  it("diamond DAG (1→2, 1→3, 2→4, 3→4) → does not report a cycle", () => {
+    const chainData: ChainData = {
+      documentos: [
+        {
+          id: "1",
+          numero: "M1",
+          tipo: "matricula",
+          cartorioId: "cartorio-1",
+          data: "2024-01-01",
+        },
+        {
+          id: "2",
+          numero: "M2",
+          tipo: "matricula",
+          cartorioId: "cartorio-1",
+          data: "2024-01-02",
+        },
+        {
+          id: "3",
+          numero: "M3",
+          tipo: "matricula",
+          cartorioId: "cartorio-1",
+          data: "2024-01-03",
+        },
+        {
+          id: "4",
+          numero: "M4",
+          tipo: "matricula",
+          cartorioId: "cartorio-1",
+          data: "2024-01-04",
+        },
+      ],
+      lancamentos: [
+        { id: "lanc-1", documentoId: "2", tipo: "registro" as LancamentoTipo },
+        { id: "lanc-2", documentoId: "3", tipo: "registro" as LancamentoTipo },
+        { id: "lanc-3", documentoId: "4", tipo: "registro" as LancamentoTipo },
+        { id: "lanc-4", documentoId: "4", tipo: "registro" as LancamentoTipo },
+      ],
+      origens: [
+        { id: "orig-1", lancamentoId: "lanc-1", documentoId: "1" },
+        { id: "orig-2", lancamentoId: "lanc-2", documentoId: "1" },
+        { id: "orig-3", lancamentoId: "lanc-3", documentoId: "2" },
+        { id: "orig-4", lancamentoId: "lanc-4", documentoId: "3" },
+      ],
+    };
+
+    const result = buildGraph(chainData);
+
+    expect(result.nodes.map((n) => n.id)).toEqual([
+      "doc-1",
+      "doc-2",
+      "doc-3",
+      "doc-4",
+      "fim-4",
+    ]);
+  });
+
   // --- Edge mapping (3 cases + MUST-FIX #2) ---
 
   it("edge with tipoOrigem provided → uses provided value", () => {
@@ -495,5 +552,64 @@ describe("buildGraph", () => {
     const fimNode = result.nodes.find((n) => n.type === "fimCadeia");
     expect(fimNode).toBeDefined();
     expect(fimNode?.data.classificacao).toBe("inconclusa");
+  });
+
+  // --- Cycle detection (2 cases) ---
+
+  it("self-loop (documento with origem pointing to itself) → throws cycle error", () => {
+    const chainData: ChainData = {
+      documentos: [
+        {
+          id: "1",
+          numero: "M1",
+          tipo: "matricula",
+          cartorioId: "cartorio-1",
+          data: "2024-01-01",
+        },
+      ],
+      lancamentos: [
+        { id: "lanc-1", documentoId: "1", tipo: "registro" as LancamentoTipo },
+      ],
+      origens: [
+        { id: "orig-1", lancamentoId: "lanc-1", documentoId: "1" }, // Self-loop
+      ],
+    };
+
+    expect(() => buildGraph(chainData)).toThrow(
+      /Cycle detected in chain data: doc-1 -> doc-1/
+    );
+  });
+
+  it("2-node cycle (doc-1 → doc-2 → doc-1) → throws cycle error", () => {
+    const chainData: ChainData = {
+      documentos: [
+        {
+          id: "1",
+          numero: "M1",
+          tipo: "matricula",
+          cartorioId: "cartorio-1",
+          data: "2024-01-01",
+        },
+        {
+          id: "2",
+          numero: "M2",
+          tipo: "matricula",
+          cartorioId: "cartorio-1",
+          data: "2024-01-02",
+        },
+      ],
+      lancamentos: [
+        { id: "lanc-1", documentoId: "2", tipo: "registro" as LancamentoTipo },
+        { id: "lanc-2", documentoId: "1", tipo: "registro" as LancamentoTipo },
+      ],
+      origens: [
+        { id: "orig-1", lancamentoId: "lanc-1", documentoId: "1" }, // 1 → 2
+        { id: "orig-2", lancamentoId: "lanc-2", documentoId: "2" }, // 2 → 1 (cycle)
+      ],
+    };
+
+    expect(() => buildGraph(chainData)).toThrow(
+      /Cycle detected in chain data: (doc-1 -> doc-2 -> doc-1|doc-2 -> doc-1 -> doc-2)/
+    );
   });
 });

--- a/packages/web/src/graph/builder.ts
+++ b/packages/web/src/graph/builder.ts
@@ -116,6 +116,11 @@ export function buildGraph(chainData: ChainData): GraphJson {
     }
   }
 
+  detectCycles(
+    edges,
+    chainData.documentos.map((d) => ensureDocPrefix(d.id))
+  );
+
   return validateGraph({ nodes, edges });
 }
 
@@ -137,4 +142,67 @@ function ensureDocPrefix(id: string): string {
  */
 function inferOrigemTipo(sourceDocTipo: DocumentoTipo): OrigemTipo {
   return sourceDocTipo === "transcricao" ? "transcricao" : "matricula";
+}
+
+/**
+ * Detects cycles in the documento graph using iterative DFS.
+ * Throws if a cycle is found, listing the involved documento IDs.
+ *
+ * Only considers documento→documento edges (not synthetic fim edges).
+ */
+function detectCycles(edges: GraphEdge[], docIds: string[]): void {
+  const adjacency = new Map<string, string[]>();
+  for (const docId of docIds) {
+    adjacency.set(docId, []);
+  }
+
+  for (const edge of edges) {
+    if (!edge.source.startsWith("doc-") || !edge.target.startsWith("doc-")) {
+      continue;
+    }
+
+    adjacency.get(edge.source)?.push(edge.target);
+  }
+
+  const states = new Map<string, "visiting" | "visited">();
+
+  for (const startNode of docIds) {
+    if (states.has(startNode)) {
+      continue;
+    }
+
+    const path: string[] = [startNode];
+    const stack: Array<{ node: string; nextNeighborIndex: number }> = [
+      { node: startNode, nextNeighborIndex: 0 },
+    ];
+    states.set(startNode, "visiting");
+
+    while (stack.length > 0) {
+      const frame = stack[stack.length - 1];
+      const neighbors = adjacency.get(frame.node);
+
+      if (neighbors === undefined || frame.nextNeighborIndex >= neighbors.length) {
+        states.set(frame.node, "visited");
+        stack.pop();
+        path.pop();
+        continue;
+      }
+
+      const neighbor = neighbors[frame.nextNeighborIndex];
+      frame.nextNeighborIndex += 1;
+
+      const neighborState = states.get(neighbor);
+      if (neighborState === "visiting") {
+        const cycleStartIndex = path.indexOf(neighbor);
+        const cycle = path.slice(cycleStartIndex).concat(neighbor);
+        throw new Error(`Cycle detected in chain data: ${cycle.join(" -> ")}`);
+      }
+
+      if (neighborState === undefined) {
+        states.set(neighbor, "visiting");
+        path.push(neighbor);
+        stack.push({ node: neighbor, nextNeighborIndex: 0 });
+      }
+    }
+  }
 }

--- a/packages/web/src/graph/mock.ts
+++ b/packages/web/src/graph/mock.ts
@@ -123,7 +123,7 @@ function generateBranching(): GraphJson {
     ],
     edges: [
       { id: "orig-1", source: "doc-1", target: "doc-2", data: { tipoOrigem: "matricula" } },
-      { id: "orig-2", source: "doc-2", target: "doc-3", data: { tipoOrigem: "transcricao" } },
+      { id: "orig-2", source: "doc-2", target: "doc-3", data: { tipoOrigem: "matricula" } },
       { id: "orig-3", source: "doc-2", target: "doc-4", data: { tipoOrigem: "matricula" } },
       { id: "doc-3->fim-3", source: "doc-3", target: "fim-3", data: { tipoOrigem: "fim_cadeia" } },
       { id: "doc-4->fim-4", source: "doc-4", target: "fim-4", data: { tipoOrigem: "fim_cadeia" } },

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -20,18 +20,16 @@ export default defineConfig({
     include: ["src/**/*.test.{ts,tsx}"],
     coverage: {
       provider: "v8",
-      reporter: ["text", "html", "lcov"],
-      // Global thresholds kept at 80% because legacy files
-      // (validateGraph.ts, topology-adapter.ts) have throw-path gaps
-      // (Pitfall #15 in .hermes/plans/T-501.md). Per-file thresholds
-      // enforce the T-501 spec gate ("100% unit test coverage on pure
-      // functions") for the new pure-function files only.
-      lines: 80,
-      functions: 80,
-      branches: 80,
-      statements: 80,
+      reporter: [["text", { skipFull: false }], "html", "lcov"],
+      // Global thresholds live under coverage.thresholds in Vitest 4.
+      // Keep them at 80% because legacy files have known throw-path gaps,
+      // while file-specific thresholds enforce the T-501 100% gate for the
+      // new pure-function files.
       thresholds: {
-        perFile: true,
+        lines: 80,
+        functions: 80,
+        branches: 80,
+        statements: 80,
         "src/graph/builder.ts": {
           lines: 100,
           functions: 100,


### PR DESCRIPTION
## Summary

Three fixes identified by gpt-5.5 xhigh review of PR #36 (merged). All are correctness/completeness issues that slipped through without the mandatory review.

### Fixes

1. **Cycle detection in `buildGraph()`** — Added iterative DFS cycle detection. The function documented that it threw on cycles but `validateGraph()` doesn't check DAG invariants. Now cyclic `ChainData` correctly throws with the cycle path in the error message.

2. **Mock `tipoOrigem` consistency** — Branching mock edge `orig-2` (doc-2 → doc-3) had `tipoOrigem: "transcricao"` but source doc-2 is `"matricula"`. Fixed to `"matricula"` per the source-inference convention used by `builder.ts` and `topology-adapter.ts`.

3. **VTitest config global thresholds** — Vitest 4 expects global `lines/functions/branches/statements` under `coverage.thresholds`, not directly under `coverage$. The 80% global threshold was silently ignored since the original PR.

### Verification

- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm test:unit` — 104 passed ✅
- `pnpm test:unit:coverage` — 104 passed, `builder.ts` 100%, `mock.ts` 100% ✅

### Review status

PR still needs gpt-5.5 xhigh merge-readiness review before merge (will run next).