### PR TITLE
docs(db): sync schema decisions from t-001-v2 and clarify doc scope

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -169,10 +169,10 @@ Phase 0: Decisions ──┐
 - **Status:** 📋 **ready to start** (T-101 merged, can run in parallel with T-200)
 - **Worktree branch:** `feat/field-filler`
 - **Files:** `scripts/seed/field-filler.ts`
-- **Description:** Uses `@faker-js/faker` to fill non-deterministic fields (names, dates, document numbers, cartórios, etc.) per the constraints from Q1–Q15 + Q11b (e.g. CNPJ/CPF format if Q5 = DB-level).
+- **Description:** Uses `@faker-js/faker` to fill non-deterministic fields (names, dates, document numbers, cartórios, etc.) per the constraints from Q1–Q15 + Q11b (e.g. ISO8601 dates, normalized numeric document numbers, INTEGER 0/1 booleans, area in centiares). **Nota:** Q5 removeu CPF/RG/email/telefone de `Pessoa`; Q4 escolheu texto puro, então não gere colunas de PII nem ciphertext.
 - **Acceptance:**
   - `field-filler(topology)` produces rows that insert without error into the Drizzle schema
-  - If Q4 = "encrypt at rest", produces ciphertext + provides decryption key path
+  - Q4=A (texto puro) e Q5=N/A (sem PII em `Pessoa`) estão refletidos no filler — nenhuma coluna de PII ou ciphertext é gerada.
 - **Blocks:** T-202.
 
 ### T-202 — Seed orchestrator
@@ -193,7 +193,7 @@ Phase 0: Decisions ──┐
 - **Status:** blocked on T-101, T-202
 - **Worktree branch:** `feat/legacy-fit-script`
 - **Files:** `scripts/migration/legacy-fit.ts`, `scripts/migration/__tests__/legacy-fit.test.ts`
-- **Description:** Loads `old/data.cleaned.core.no-auth.no-unistr.sql` (3.3MB Postgres dump) into the new Drizzle schema, then asserts: row counts match expected per table, no FK violations, no `NOT NULL` failures, no `CHECK` failures (if Q5 = DB-level). Emits a human-readable report.
+- **Description:** Loads `old/data.cleaned.core.no-auth.no-unistr.sql` (3.3MB Postgres dump) into the new Drizzle schema, then asserts: row counts match expected per table, no FK violations, no `NOT NULL` failures, no `CHECK` failures. Emits a human-readable report.
 - **Acceptance:**
   - `pnpm legacy-fit` exits 0 on a clean run
   - Report shows: ✓ row count per table, ✓ FK check, ✓ NOT NULL check, ✓ (optional) CHECK check

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -63,7 +63,7 @@ Phase 0: Decisions ──┐
 ### T-101 — Author the Drizzle schema
 - **Status:** ✅ done (PR #25 merged). Codex 5/5 APROVA (round 4).
 - **Worktree branch:** `feat/drizzle-schema-v2` (merged + cleaned)
-- **Files:** `packages/api/drizzle/schema/` (19 files), `packages/api/drizzle/migrations/0000_real_quentin_quire.sql` (297 linhas, 17 tables + 2 views + 13 indexes)
+- **Files:** `packages/api/drizzle/schema/` (19 arquivos `.ts` incluindo views). Migrations SQL são geradas on-demand (`pnpm db:generate`) e **não estão commitadas** no repo (apenas `.gitkeep`).
 - **Description:** Translate Django models → Drizzle ORM. All Q1-Q15 decisions implemented. PII removed (Q5), soft-delete on all tables (Q2), `cri` table with `tipo` CHECK (Q11b), N:N junction `imovel_documento` (Q13), `lancamento_move_event` append-only (Q14), `audit_log` (Q9).
 - **Acceptance:** ✅ `db:generate` clean, `db:migrate:local` clean, 100% type-safe, CI 4/4 green.
 - **Blocks:** T-200, T-201, T-300.

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -40,7 +40,7 @@ Phase 0: Decisions ──┐
 - **Depends on:** nothing.
 - **Blocks:** T-001.
 
-### T-001 — Answer Q1–Q6
+### T-001 — Answer Q1–Q15 + Q11b
 - **Status:** ✅ done (PR #24 merged). Extended to Q1-Q15 + Q11b.
 - **Owner:** Luandro (project lead)
 - **Description:** Provide a decision for each of Q1 through Q15 + Q11b. Codex gpt-5.5 xhigh 5/5 APROVA. Opus 4.8 5/5 APROVA.

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -30,7 +30,7 @@ Phase 0: Decisions ──┐
 
 ## Phase 0 — Decisions (BLOCKING)
 
-> Nothing in Phase 1 can start until all 6 decisions in `docs/db/SCHEMA_DECISOES_PENDENTES.md` are answered.
+> Nothing in Phase 1 can start until all 6 decisions in `docs/db/SCHEMA_DECISOES_PENDENTES.md` are answered. **Decisions are recorded; this phase is closed.**
 
 ### T-000 — Read the pending decisions
 - **Status:** ✅ done (2026-06-02/03, Luandro + Hiure)
@@ -46,7 +46,7 @@ Phase 0: Decisions ──┐
 - **Description:** Provide a decision for each of Q1 through Q15 + Q11b. Codex gpt-5.5 xhigh 5/5 APROVA. Opus 4.8 5/5 APROVA.
 - **Output:** `docs/db/SCHEMA_DECISOES_PENDENTES.md` with all answers + rationale.
 - **Acceptance:** All questions answered, no TBDs remain. ✅
-- **Blocks:** all of Phase 1.
+- **Blocks:** all of Phase 1. **Unblocked now.**
 
 ---
 
@@ -246,7 +246,9 @@ Phase 0: Decisions ──┐
 ## Related documents
 
 - `docs/SCHEMA_V2_BLINDSPOT_REVIEW.md` — the 27-issue audit (PR #15)
-- `docs/db/SCHEMA_DECISOES_PENDENTES.md` — the 6 blocking decisions (in pt-BR, this PR)
+- `docs/db/SCHEMA_DECISOES_PENDENTES.md` — **architecture decisions** Q1–Q15 + Q11b (this PR)
+- `docs/db/SCHEMA_QUESTOES.md` — **detailed column-level questions** Q1–Q25
+- `docs/db/SCHEMA_RESPOSTAS.md` — **answers** to the detailed column-level questions
 - `docs/ERD_CADEIA_DOMINIAL.md` — the schema draft (target of T-100). **Note:** as of the docs/ restructure (T-403, PR #17), the v2 ERD is at `docs/db/erd-v2.mmd` and the legacy Django ERD will be moved to `docs/legacy-django/erd-modelo-antigo.md` in a follow-up.
 - `docs/legacy-django/03-database-models.md` — Django source of truth
 - `docs/MIGRATION_GUIDE.md` — overall migration architecture

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -30,12 +30,12 @@ Phase 0: Decisions ──┐
 
 ## Phase 0 — Decisions (BLOCKING)
 
-> Nothing in Phase 1 can start until all 6 decisions in `docs/db/SCHEMA_DECISOES_PENDENTES.md` are answered. **Decisions are recorded; this phase is closed.**
+> Nothing in Phase 1 can start until all Q1–Q15 + Q11b decisions in `docs/db/SCHEMA_DECISOES_PENDENTES.md` are answered. **Decisions are recorded; this phase is closed.**
 
 ### T-000 — Read the pending decisions
 - **Status:** ✅ done (2026-06-02/03, Luandro + Hiure)
 - **Owner:** anyone (Luandro, Hiure, or reviewer)
-- **Description:** Read `docs/db/SCHEMA_DECISOES_PENDENTES.md` end-to-end. For each of the 6 questions (Q1–Q6), understand the trade-offs, especially the visual impact on the React Flow graph.
+- **Description:** Read `docs/db/SCHEMA_DECISOES_PENDENTES.md` end-to-end. For each of the questions (Q1–Q15 + Q11b), understand the trade-offs, especially the visual impact on the React Flow graph.
 - **Acceptance:** Decision-maker can articulate each question + at least one option's DB/chain-graph consequence without re-reading the doc. ✅
 - **Depends on:** nothing.
 - **Blocks:** T-001.
@@ -169,7 +169,7 @@ Phase 0: Decisions ──┐
 - **Status:** 📋 **ready to start** (T-101 merged, can run in parallel with T-200)
 - **Worktree branch:** `feat/field-filler`
 - **Files:** `scripts/seed/field-filler.ts`
-- **Description:** Uses `@faker-js/faker` to fill non-deterministic fields (names, dates, document numbers, cartórios, etc.) per the constraints from Q1–Q6 (e.g. CNPJ/CPF format if Q5 = DB-level).
+- **Description:** Uses `@faker-js/faker` to fill non-deterministic fields (names, dates, document numbers, cartórios, etc.) per the constraints from Q1–Q15 + Q11b (e.g. CNPJ/CPF format if Q5 = DB-level).
 - **Acceptance:**
   - `field-filler(topology)` produces rows that insert without error into the Drizzle schema
   - If Q4 = "encrypt at rest", produces ciphertext + provides decryption key path

--- a/docs/db/SCHEMA_DECISOES_PENDENTES.md
+++ b/docs/db/SCHEMA_DECISOES_PENDENTES.md
@@ -616,8 +616,9 @@ cri {
   int id PK
   text nome "1º Cartório de Registro de Imóveis de Salvador"
   text cidade
-  text uf
-  text CNS_codigo "Cadastro Nacional de Serventia (TBD)"
+  text uf "27 UFs, validado na app (sem CHECK no DB)"
+  text cns_codigo "Cadastro Nacional de Serventia (TBD)"
+  text tipo "CHECK in (CRI, OUTRO), DEFAULT CRI (T-100)"
   // ... outros campos espelhando API do Sistema Nacional de Cartórios
   text created_at
   text updated_at
@@ -809,12 +810,7 @@ Regra UI-only ("L aparece na chain de D' se existe move event mais recente com `
 CREATE VIEW v_lancamento_current_location AS
 SELECT
   l.id AS lancamento_id,
-  COALESCE(last_move.to_documento_id, l.documento_id) AS current_documento_id,
-  CASE
-    WHEN last_move.lancamento_id IS NULL THEN 'ORIGINAL'
-    WHEN last_move.to_documento_id IS NULL THEN 'PRESO'
-    ELSE 'MOVED'
-  END AS location_state
+  COALESCE(last_move.to_documento_id, l.documento_id) AS current_documento_id
 FROM lancamento l
 LEFT JOIN (
   -- Most recent MOVE event per Lancamento (append-only, Q14=B)
@@ -844,7 +840,7 @@ WHERE l.deleted_at IS NULL
 - "Mostrar L na chain de D" → `JOIN lancamento l ON l.id = ? JOIN v_lancamento_current_location v ON v.lancamento_id = l.id WHERE v.current_documento_id = D`
 - "Quais L's estão em D'?" → query acima
 - "Histórico de moves do L" → `SELECT * FROM lancamento_move_event WHERE lancamento_id = L ORDER BY moved_at, id`
-- **Lançamentos "presos"** (último MOVE com `to_documento_id = NULL`, Q15=🅳️) **NÃO aparecem** nesta view. Para listá-los: `SELECT l.* FROM lancamento l INNER JOIN lancamento_move_event me ON me.id = (SELECT id FROM lancamento_move_event me2 WHERE me2.lancamento_id = l.id ORDER BY me2.moved_at DESC, me2.id DESC LIMIT 1) WHERE me.to_documento_id IS NULL AND l.deleted_at IS NULL` (o `INNER JOIN` é proposital — exige que exista pelo menos 1 move event; sem move, L aparece como ORIGINAL na view, não como PRESO). A coluna `location_state` (`ORIGINAL` / `MOVED` / `PRESO`) explicita a origem do `current_documento_id` retornado — use-a em vez de inferir do NULL/NOT NULL.
+- **Lançamentos "presos"** (último MOVE com `to_documento_id = NULL`, Q15=🅳️) **NÃO aparecem** nesta view. Para listá-los: `SELECT l.* FROM lancamento l INNER JOIN lancamento_move_event me ON me.id = (SELECT id FROM lancamento_move_event me2 WHERE me2.lancamento_id = l.id ORDER BY me2.moved_at DESC, me2.id DESC LIMIT 1) WHERE me.to_documento_id IS NULL AND l.deleted_at IS NULL` (o `INNER JOIN` é proposital — exige que exista pelo menos 1 move event; sem move, L aparece com `current_documento_id = l.documento_id` na view, não como PRESO). O estado (`ORIGINAL` / `MOVED` / `PRESO`) deve ser inferido pelo consumidor: `ORIGINAL` quando não há move event, `MOVED` quando `current_documento_id` veio de `to_documento_id`, e `PRESO` quando o último move event tem `to_documento_id IS NULL`.
 
 **D1/SQLite support:** `CREATE VIEW` totalmente suportado. Custo: index em `lancamento_move_event(lancamento_id, moved_at DESC, id DESC)` para performance (Drizzle adiciona via `CREATE INDEX` na migration T-101).
 

--- a/docs/db/SCHEMA_DECISOES_PENDENTES.md
+++ b/docs/db/SCHEMA_DECISOES_PENDENTES.md
@@ -1,6 +1,8 @@
-# Decisões Pendentes do Schema v2
+# Decisões do Schema v2
 
 > **Quem deve ler isso:** Luandro (decisor final), Hiure (implementador), e qualquer pessoa que queira entender por que o schema v2 está do jeito que está. Este documento é em português para ser acessível a pessoas não-desenvolvedoras, mas mantém a precisão técnica.
+>
+> **Escopo deste documento:** este arquivo contém as **decisões de arquitetura de alto nível** do schema v2 (Q1–Q15 + Q11b): cascade/soft-delete, cardinalidade de fim de cadeia, criptografia de PII, validação de CPF/CNPJ, visualização do grafo, etc. As **perguntas técnicas detalhadas** de coluna (Q1–Q25) estão em `docs/db/SCHEMA_QUESTOES.md` e as respostas em `docs/db/SCHEMA_RESPOSTAS.md`. Se você chegou aqui procurando por "qual o CHECK de `origem.indice`", vá para `SCHEMA_RESPOSTAS.md`; se chegou perguntando "apagar imóvel apaga tudo?", continue aqui.
 >
 > **Por que este documento existe:** A revisão cega do schema v2 (em `docs/SCHEMA_V2_BLINDSPOT_REVIEW.md`) encontrou 27 pontos cegos. Dez deles não podem ser resolvidos sem uma decisão humana. **A partir da sessão de grupo de 2026-06-02/03 com Luandro (decisor) e Hiure (implementador), 15 perguntas (Q1–Q15, mais a Q11b) foram decididas.** A Crítica Codex 2026-06-03 (gpt-5.5, high) encontrou 8 blockers; o round 2 pós-D1–D4 + T1–T4 encontrou mais 2 BLOCKERS e 1 nice-to-have — todos resolvidos antes do PR.
 
@@ -417,7 +419,9 @@ CREATE TABLE pessoa (
 **🌳 Como fica no grafo:** Sem impacto direto. UI formata para "123.456.789-01" na exibição.
 
 ### ✅ Recomendação
-**Opção C (normalizado no banco, validado na app)** — é a melhor prática da indústria. CHECK constraint garante integridade mesmo se a app falhar. UI formata para exibição. Migrar dados antigos exige um script de normalização (que o `legacy-fit` script — T-300 — pode fazer).
+**HISTÓRICO (round 1, 2026-06-03):** "Opção C (normalizado no banco, validado na app)" parecia a melhor prática da indústria. CHECK constraint garantiria integridade mesmo se a app falhasse. UI formataria para exibição. Migrar dados antigos exigiria um script de normalização (que o `legacy-fit` script — T-300 — poderia fazer).
+
+> **⚠️ DECISÃO FINAL (round 2, 2026-06-03) — SOBRESCREVE a recomendação acima:** **REMOVER** `cpf`/`rg`/`data_nascimento`/`email`/`telefone` de `Pessoa` no v2. Q5b vira N/A. Coerente com Q2/Q4: v2 não é sistema de PII, é cópia fiel do cartório + análise. Pesquisadores não precisam do CPF dentro do sistema — quem precisa cruza com bases externas (Receita, processos judiciais). Sub-task explícita do T-300: "definir quais colunas descartar do legado no v2".
 
 ---
 
@@ -576,7 +580,7 @@ O padrão `campo_raw` (verbatim) + `campo` (normalized pra busca) deve ser aplic
 - `documento.cartorio_id` é FK pra `cartorio.id`
 - Sem campo "outros" / texto livre — pesquisador preenche a mesma estrutura da API
 
-> **⚠️ Q11b (NOVA — Hiure, 2026-06-03):** refinamento da decisão. Ver seção dedicada abaixo.
+> **⚠️ Q11b (NOVA — Hiure, 2026-06-03) — SOBRESCREVE o texto acima:** ver seção dedicada abaixo. Resumo: tabela vira `cri` (não `cartorio` genérico), `documento.cri_id` FK direto sem junction, `imovel.cri_id` fixo sem histórico, `UNIQUE (cri_id, tipo, numero)`, `cartorio_transmissao` permanece campo livre (não vira tabela).
 
 ---
 
@@ -594,7 +598,7 @@ O padrão `campo_raw` (verbatim) + `campo` (normalized pra busca) deve ser aplic
 
 **Resposta (Hiure, 2026-06-03): NÃO no v1.** Quando pesquisadores pegam o documento, isso já foi consolidado e não deve mudar. `imovel.cri_id` é fixo (FK direto, sem histórico). Se v2+ precisar, criar `imovel_cri_historico` na hora.
 
-> **Importante (Hiure):** "sempre manter a unicidade de documentos com `cartorio + numero_documento` (M ou T + número)" — constraint de unicidade deve ser pelo par `(cartorio_id, tipo, numero)`, não só pelo número.
+> **Importante (Hiure):** "sempre manter a unicidade de documentos com `cartorio + numero_documento` (M ou T + número)" — constraint de unicidade deve ser pelo par `(cri_id, tipo, numero)`, não só pelo número. (Nota: `cartorio_id` era terminologia pré-Q11b; usar `cri_id` no v2.)
 
 ### 🅲️ Cada Documento tem 1 CRI só? Ou N:N (junction)?
 **Pergunta:** `documento.cri_id` FK direto, ou junction `documento_cri` (N:N)?
@@ -610,7 +614,6 @@ O padrão `campo_raw` (verbatim) + `campo` (normalized pra busca) deve ser aplic
 ```
 cri {
   int id PK
-  text tipo "CRI ou OUTRO (CHECK tipo IN (CRI,OUTRO), DEFAULT CRI). T-100: parity com Django Cartorios.tipo"
   text nome "1º Cartório de Registro de Imóveis de Salvador"
   text cidade
   text uf
@@ -636,13 +639,22 @@ documento {
 
 imovel {
   int id PK
-  int cri_id FK                  // fixo, sem histórico no v1
+  int cri_id FK                  // fixo, sem histórico no v1 (Q11b=🅱️)
   int proprietario_id FK
   int arquivado "0/1"
   text created_at
   text deleted_at
-  // (Q11b=🅲️) v1: imovel_id direto no documento (sem junction imovel_documento)
-  //             Q13=N:N com junction vem depois (ver Q13 abaixo)
+}
+
+imovel_documento {                 // Q13=🅱️: junction N:N (NÃO tem imovel_id direto em documento)
+  int id PK
+  int imovel_id FK
+  int documento_id FK
+  int is_documento_atual "0/1, per-par"
+  text created_at
+  text deleted_at
+  UNIQUE (imovel_id, documento_id) WHERE deleted_at IS NULL
+  UNIQUE (imovel_id) WHERE is_documento_atual = 1 AND deleted_at IS NULL
 }
 
 lancamento {
@@ -665,7 +677,7 @@ origem {
   int id PK
   int lancamento_id FK
   int indice "0, 1, 2..."
-  int cri_id FK                  // CRI de origem (Q11b=🅰️: este campo já é o "cri_origem_id")
+  int cri_id FK                  // CRI de origem (Q11b=🅰️: este campo já é o "cri_origem_id", RESTRICT)
   int documento_id FK "opcional"
   text tipo "matricula | transcricao | fim_cadeia"
   text numero
@@ -673,6 +685,7 @@ origem {
   text folha
   text data
   text observacoes
+  text deleted_at "soft-delete (Q2=B). Origem preserva evidencia de divergencia entre certidoes"
   UNIQUE (lancamento_id, indice)
 }
 ```
@@ -795,30 +808,43 @@ Regra UI-only ("L aparece na chain de D' se existe move event mais recente com `
 ```sql
 CREATE VIEW v_lancamento_current_location AS
 SELECT
-  inner_q.lancamento_id,
-  inner_q.current_documento_id
-FROM (
-  SELECT
-    l.id AS lancamento_id,
-    COALESCE(
-      (SELECT me.to_documento_id
-       FROM lancamento_move_event me
-       WHERE me.lancamento_id = l.id
-       ORDER BY me.moved_at DESC, me.id DESC
-       LIMIT 1),
-      l.documento_id
-    ) AS current_documento_id
-  FROM lancamento l
-  WHERE l.deleted_at IS NULL
-) inner_q
-INNER JOIN documento d ON d.id = inner_q.current_documento_id
-WHERE d.deleted_at IS NULL;
+  l.id AS lancamento_id,
+  COALESCE(last_move.to_documento_id, l.documento_id) AS current_documento_id,
+  CASE
+    WHEN last_move.lancamento_id IS NULL THEN 'ORIGINAL'
+    WHEN last_move.to_documento_id IS NULL THEN 'PRESO'
+    ELSE 'MOVED'
+  END AS location_state
+FROM lancamento l
+LEFT JOIN (
+  -- Most recent MOVE event per Lancamento (append-only, Q14=B)
+  SELECT me.lancamento_id, me.to_documento_id
+  FROM lancamento_move_event me
+  WHERE me.id = (
+    SELECT me2.id
+    FROM lancamento_move_event me2
+    WHERE me2.lancamento_id = me.lancamento_id
+    ORDER BY me2.moved_at DESC, me2.id DESC
+    LIMIT 1
+  )
+) last_move ON last_move.lancamento_id = l.id
+INNER JOIN documento d ON d.id = COALESCE(last_move.to_documento_id, l.documento_id)
+WHERE l.deleted_at IS NULL
+  AND d.deleted_at IS NULL
+  -- Distinguish "no move event" (l.documento_id is canonical, ORIGINAL)
+  -- from "move event with target NULL" (PRESO state, Q15=🅳️):
+  -- exclude rows whose current move target is NULL.
+  -- A Lancamento sem move event aparece com current_documento_id = l.documento_id.
+  -- Um Lancamento com move event aparece com current_documento_id = me.to_documento_id.
+  -- Um Lancamento "preso" (último MOVE com to_documento_id NULL) NÃO aparece nesta view.
+  AND (last_move.lancamento_id IS NULL OR last_move.to_documento_id IS NOT NULL);
 ```
 
 **Como a UI consome:**
 - "Mostrar L na chain de D" → `JOIN lancamento l ON l.id = ? JOIN v_lancamento_current_location v ON v.lancamento_id = l.id WHERE v.current_documento_id = D`
 - "Quais L's estão em D'?" → query acima
 - "Histórico de moves do L" → `SELECT * FROM lancamento_move_event WHERE lancamento_id = L ORDER BY moved_at, id`
+- **Lançamentos "presos"** (último MOVE com `to_documento_id = NULL`, Q15=🅳️) **NÃO aparecem** nesta view. Para listá-los: `SELECT l.* FROM lancamento l INNER JOIN lancamento_move_event me ON me.id = (SELECT id FROM lancamento_move_event me2 WHERE me2.lancamento_id = l.id ORDER BY me2.moved_at DESC, me2.id DESC LIMIT 1) WHERE me.to_documento_id IS NULL AND l.deleted_at IS NULL` (o `INNER JOIN` é proposital — exige que exista pelo menos 1 move event; sem move, L aparece como ORIGINAL na view, não como PRESO). A coluna `location_state` (`ORIGINAL` / `MOVED` / `PRESO`) explicita a origem do `current_documento_id` retornado — use-a em vez de inferir do NULL/NOT NULL.
 
 **D1/SQLite support:** `CREATE VIEW` totalmente suportado. Custo: index em `lancamento_move_event(lancamento_id, moved_at DESC, id DESC)` para performance (Drizzle adiciona via `CREATE INDEX` na migration T-101).
 
@@ -927,7 +953,7 @@ Usuário clica "Apagar" em Documento D
 | Q7b | Cascade delete Imóvel | **🅱️** Cascade conservador: I + junctions, L's preservados | Lancamentos são evidência — devem sobreviver órfãos. Cascade em junctions `imovel_documento` apenas. |
 | Q8 | Restore semantics | **🅰️** Simétrico ao Q7b=B | Intuitivo ("restaurar = desfazer"). Soft-delete foi conservador, nada de "lixo" pra restaurar. |
 | Q9 | Trilha de análise | **🅲️** Histórico + provenance de criação | Crítico em equipe (autor original vs editor). |
-| Q10 | Raw vs normalized | **🅰️** com exceção de `cartorio_nome` | Demais campos variáveis usam busca fuzzy FTS5. `cartorio_nome` vira entidade própria (tabela `cartorio`). |
+| Q10 | Raw vs normalized | **🅰️** com exceção de `cri.nome` | Demais campos variáveis usam busca fuzzy FTS5. `cri.nome` vira entidade própria (tabela `cri`, ver Q11b). |
 | Q11b | Refinamento Q10 sobre `cri` | **Ver Q11b acima** | `cri` table (não genérico `cartorio`); `documento.cri_id` FK direto (sem junction); `UNIQUE (cri_id, tipo, numero)`; `cartorio_transmissao` é campo livre, não tabela; `imovel.cri_id` fixo (sem histórico v1). |
 | Q12 | UX confirmation dialog | **🅳️** preview ANTES + dialog | "É importante perguntar se quer mesmo apagar ou se quer só editar" (Hiure, 2026-06-02). |
 | Q13 | Chain membership | **🅱️** Junction `imovel_documento` (N:N) | "Pertence igualmente a diferentes imóveis" (Hiure, 2026-06-02). `is_documento_atual` per-par. |
@@ -990,6 +1016,7 @@ Toda FK precisa ter `onDelete` explícito. Defaults Drizzle = `NO ACTION` (= RES
 |---|---|---|
 | `documento.cri_id` → `cri.id` | `RESTRICT` | Não pode apagar CRI com docs; admin tem hard-delete separado |
 | `imovel.cri_id` → `cri.id` | `RESTRICT` | Mesmo |
+| `imovel.proprietario_id` → `pessoa.id` | `SET NULL` | Q2=B: LGPD anonymization do dono; imovel permanece com `created_at`/`updated_at`/`deleted_at` próprios |
 | `origem.cri_id` → `cri.id` | `RESTRICT` | Mesmo |
 | `origem.lancamento_id` → `lancamento.id` | `RESTRICT` | Q3 (round 3): `origem` carrega evidência verbatim (`numero_raw`); CASCADE apagaria evidência junto com L. RESTRICT protege a cadeia forense. Hard-delete de L é admin-only e explícito. |
 | `lancamento.documento_id` → `documento.id` | `SET NULL` | Q7b=B: L preservado órfão se D sumir |
@@ -1008,11 +1035,18 @@ Toda FK precisa ter `onDelete` explícito. Defaults Drizzle = `NO ACTION` (= RES
 | `lancamento_move_event.moved_by_id` → `user.id` | `SET NULL` | Pesquisador removido, evento preservado |
 | `lancamento_move_event.audit_log_id` → `audit_log.id` | `SET NULL` | Audit log pode ser purgado, evento preservado |
 | `origem.documento_id` → `documento.id` | `SET NULL` | Origem órfã se D sumir; tipo=fim_cadeia tem NULL anyway |
-| `user.deleted_at` | (no FK) | n/a |
+| `origem_fim_cadeia.origem_id` → `origem.id` | `CASCADE` | Junction 1:1, segue a origem |
+| `imovel.delete_operation_id` → `audit_log.id` | `SET NULL` | Q9=C: provenance do soft-delete do imovel |
+| `imovel_documento.delete_operation_id` → `audit_log.id` | `SET NULL` | Q9=C: provenance do soft-delete da chain membership |
+| `imovel_documento.create_operation_id` → `audit_log.id` | `SET NULL` | Q9=C: provenance de criação da chain membership |
+| `documento.delete_operation_id` → `audit_log.id` | `SET NULL` | Q9=C: provenance do soft-delete do documento |
+| `documento.create_operation_id` → `audit_log.id` | `SET NULL` | Q9=C: provenance de criação do documento |
+| `lancamento.delete_operation_id` → `audit_log.id` | `SET NULL` | Q9=C: provenance do soft-delete do lancamento |
 | `audit_log.actor_id` → `user.id` | `SET NULL` | LGPD: pesquisador pode pedir remoção, log preservado |
-| `audit_log.deleted_at` | (no FK) | n/a |
 | `tis_imovel.*` | `CASCADE` | Junction simples |
 | `tis.terra_referencia_id` → `terra_indigena_referencia.id` | `RESTRICT` | Referência oficial não pode sumir com TIs em uso |
+
+**Nota sobre soft-delete:** A coluna `deleted_at` existe em `cri`, `user`, `pessoa`, `imovel`, `imovel_documento`, `documento`, `lancamento`, `lancamento_pessoa`, `origem`, `anotacao_versao` (Q2=B) — não é FK, é timestamp ISO8601 NULL. **`audit_log` é a exceção explícita: NÃO tem `deleted_at`** (Q2). É append-only imutável; LGPD purge do pesquisador faz `actor_id → NULL` (SET NULL acima), o log permanece. **`lancamento_move_event` também NÃO tem `deleted_at`** (Q14=B: append-only).
 
 **Invariante Q14 (write-time, no app antes de INSERT):**
 ```ts
@@ -1096,6 +1130,11 @@ CREATE UNIQUE INDEX uq_imovel_documento_pair
 CREATE UNIQUE INDEX uq_imovel_documento_atual
   ON imovel_documento(imovel_id)
   WHERE is_documento_atual = 1 AND deleted_at IS NULL;
+
+-- Q9=C + F2 round 2: no máximo 1 versão "atual" por (imovel_documento_id)
+CREATE UNIQUE INDEX uq_anotacao_versao_current
+  ON anotacao_versao(imovel_documento_id)
+  WHERE is_current = 1 AND deleted_at IS NULL;
 
 -- T1+D1: UNIQUE no cri por CNS ativo
 CREATE UNIQUE INDEX uq_cri_cns
@@ -1228,6 +1267,8 @@ Ambas views são D1-compatíveis (CREATE VIEW suportado em SQLite). Implementaç
 **R3-8** (Codex #2 dup) e **R3-4 dup** (Greptile P1 duplicata de R3-1) — não contados separadamente.
 
 **Verdict final após fixes (pendente round 3 review):** Aguardando aprovação do Codex round 3 para confirmar APROVA.
+
+> **⚠️ ATUALIZAÇÃO 2026-06-04 (round 4 review, gpt-5.5 xhigh):** O round 3 "APROVA" interno **NÃO foi confirmado por review externo fresh** — encontrou 1 BLOCKER (cardinalidade ERD errada para FKs nullable) + 4 MUST-FIX (FK table incompleta, audit_log.deleted_at inexistente, Q5/Q10 texto stale) + 3 NICE-TO-HAVE (snippet, legend, este status). **Todos os 8 fixes aplicados nesta seção.** Próximo round 5 review revalidará o APROVA 5/5.
 
 ---
 

--- a/docs/db/SCHEMA_DECISOES_PENDENTES.md
+++ b/docs/db/SCHEMA_DECISOES_PENDENTES.md
@@ -1101,7 +1101,7 @@ WHERE pessoa_fts MATCH 'joao silva*'
 ORDER BY rank;
 ```
 
-**Drizzle:** a tabela virtual FTS5 e os triggers vão via `sql.raw` na migration (Drizzle não tem DSL nativo pra FTS5). Helper: `scripts/db/fts5-helper.ts` (a criar em T-101) que gera SQL parametrizado pelo schema.
+**Drizzle:** a tabela virtual FTS5 e os triggers vão via `sql.raw` na migration quando implementados. **FTS5 não está na migration T-101** — é tarefa futura (ver comentários em `documento.ts`, `pessoa.ts`, `anotacao_versao.ts`). Helper: `scripts/db/fts5-helper.ts` (a criar).
 
 **Aplicar a:**
 - `pessoa.nome` (Q4=A, sem criptografia)
@@ -1168,19 +1168,22 @@ Aplicar via migration Drizzle em todos os enums e constraints:
 
 - `cri.tipo` → `CHECK (tipo IN ('CRI','OUTRO'))` (T-100)
 - `lancamento_tipo.tipo` → `CHECK (tipo IN ('inicio_matricula','registro','averbacao'))`
+- `lancamento_tipo.requer_*` → `CHECK` composto: todos os 10 booleans `IN (0,1)`
 - `documento.tipo` → `CHECK (tipo IN ('matricula','transcricao'))`
 - `origem.tipo` → `CHECK (tipo IN ('matricula','transcricao','fim_cadeia'))`
 - `origem.indice` → `CHECK (indice >= 0)`
 - `lancamento_pessoa.papel` → `CHECK (papel IN ('transmitente','adquirente','outorgante','outorgado','anuente','testemunha'))`
+- `origem_fim_cadeia.tipo_fim_cadeia` → `CHECK (tipo_fim_cadeia IS NULL OR tipo_fim_cadeia IN ('destacamento_publico','sem_origem','outra'))`
 - `audit_log.action` → `CHECK (action IN ('CREATE','EDIT','SOFT_DELETE','RESTORE','MOVE','ANNOTATE','EXPORT'))`
 - `imovel.arquivado` → `CHECK (arquivado IN (0,1))`
 - `imovel_documento.is_documento_atual` → `CHECK (is_documento_atual IN (0,1))`
 - `anotacao_versao.is_current` → `CHECK (is_current IN (0,1))`
+- `anotacao_versao.versao` → `CHECK (versao > 0)`
 - `lancamento.numero_lancamento` → `CHECK (numero_lancamento > 0)` (parcial: WHERE NOT NULL)
 - `lancamento_move_event.reason` → `CHECK (length(reason) > 0)` (Q12=D)
-- `v2_user.deleted_at IS NULL OR deleted_at GLOB '[0-9]*'` (data válida, opcional)
+- `v2_user.deleted_at IS NULL OR deleted_at GLOB '[0-9]*'` (data válida, opcional — não implementado na migration T-101)
 
-> **Nota sobre Mermaid ERD (T4):** o .mmd (`erd-v2.mmd`) é **documentação visual**, NÃO schema canônico. Tipos `text` no Mermaid correspondem a `TEXT` no D1, mas a versão executável é a Drizzle migration (T-101). `UNIQUE_NOTE` é só annotation visual — partial UNIQUE indexes (`WHERE deleted_at IS NULL`), CHECK constraints, FTS5 sync triggers, e views (`v_lancamento_current_location`, `v_documento_orfao`) NÃO aparecem no .mmd; aplicar via migration Drizzle + SQL DDL. **Mermaid interpreta `--` e `|` em comentários como relações**, então CHECK constraints detalhados vão no .md, não no .mmd.
+> **Nota sobre Mermaid ERD (T4):** o .mmd (`erd-v2.mmd`) é **documentação visual**, NÃO schema canônico. Tipos `text` no Mermaid correspondem a `TEXT` no D1, mas a versão executável é a Drizzle migration (T-101). `UNIQUE_NOTE` é só annotation visual — partial UNIQUE indexes (`WHERE deleted_at IS NULL`), CHECK constraints, views (`v_lancamento_current_location`, `v_documento_orfao`) e FTS5 sync triggers (tarefa futura) NÃO aparecem no .mmd; aplicar via migration Drizzle + SQL DDL quando implementados. **Mermaid interpreta `--` e `|` em comentários como relações**, então CHECK constraints detalhados vão no .md, não no .mmd.
 
 ---
 

--- a/docs/db/SCHEMA_DECISOES_PENDENTES.md
+++ b/docs/db/SCHEMA_DECISOES_PENDENTES.md
@@ -811,10 +811,13 @@ Regra UI-only ("L aparece na chain de D' se existe move event mais recente com `
 CREATE VIEW v_lancamento_current_location AS
 SELECT
   l.id AS lancamento_id,
-  COALESCE(last_move.to_documento_id, l.documento_id) AS current_documento_id
+  CASE
+    WHEN latest.lancamento_id IS NULL THEN l.documento_id
+    ELSE latest.to_documento_id
+  END AS current_documento_id
 FROM lancamento l
 LEFT JOIN (
-  -- Most recent MOVE event per Lancamento (append-only, Q14=B)
+  -- Most recent MOVE event por Lancamento (append-only, Q14=B)
   SELECT me.lancamento_id, me.to_documento_id
   FROM lancamento_move_event me
   WHERE me.id = (
@@ -824,12 +827,15 @@ LEFT JOIN (
     ORDER BY me2.moved_at DESC, me2.id DESC
     LIMIT 1
   )
-) last_move ON last_move.lancamento_id = l.id
-INNER JOIN documento d ON d.id = COALESCE(last_move.to_documento_id, l.documento_id)
+) latest ON latest.lancamento_id = l.id
+INNER JOIN documento d ON d.id = CASE
+  WHEN latest.lancamento_id IS NULL THEN l.documento_id
+  ELSE latest.to_documento_id
+END
 WHERE l.deleted_at IS NULL
-  AND d.deleted_at IS NULL
-  -- PRESO: se o ultimo MOVE tem to_documento_id = NULL, o lancamento NAO aparece aqui
-  AND (last_move.lancamento_id IS NULL OR last_move.to_documento_id IS NOT NULL);
+  AND d.deleted_at IS NULL;
+-- PRESO: se o ultimo MOVE tem to_documento_id = NULL, o INNER JOIN em documento falha
+-- e o lancamento NAO aparece nesta view (consistente com Q15=🅳️).
 ```
 
 **Como a UI consome:**
@@ -1124,7 +1130,7 @@ CREATE UNIQUE INDEX uq_imovel_documento_atual
   WHERE is_documento_atual = 1 AND deleted_at IS NULL;
 
 -- Q9=C + F2 round 2: no máximo 1 versão "atual" por (imovel_documento_id)
-CREATE UNIQUE INDEX uq_anotacao_versao_current
+CREATE UNIQUE INDEX uq_anotacao_versao_imovel_documento_current
   ON anotacao_versao(imovel_documento_id)
   WHERE is_current = 1 AND deleted_at IS NULL;
 

--- a/docs/db/SCHEMA_DECISOES_PENDENTES.md
+++ b/docs/db/SCHEMA_DECISOES_PENDENTES.md
@@ -828,12 +828,7 @@ LEFT JOIN (
 INNER JOIN documento d ON d.id = COALESCE(last_move.to_documento_id, l.documento_id)
 WHERE l.deleted_at IS NULL
   AND d.deleted_at IS NULL
-  -- Distinguish "no move event" (l.documento_id is canonical, ORIGINAL)
-  -- from "move event with target NULL" (PRESO state, Q15=🅳️):
-  -- exclude rows whose current move target is NULL.
-  -- A Lancamento sem move event aparece com current_documento_id = l.documento_id.
-  -- Um Lancamento com move event aparece com current_documento_id = me.to_documento_id.
-  -- Um Lancamento "preso" (último MOVE com to_documento_id NULL) NÃO aparece nesta view.
+  -- PRESO: se o ultimo MOVE tem to_documento_id = NULL, o lancamento NAO aparece aqui
   AND (last_move.lancamento_id IS NULL OR last_move.to_documento_id IS NOT NULL);
 ```
 

--- a/docs/db/SCHEMA_DECISOES_PENDENTES.md
+++ b/docs/db/SCHEMA_DECISOES_PENDENTES.md
@@ -622,6 +622,7 @@ cri {
   // ... outros campos espelhando API do Sistema Nacional de Cartórios
   text created_at
   text updated_at
+  text deleted_at "soft-delete (Q2=B)"
 }
 
 documento {

--- a/docs/db/SCHEMA_DECISOES_PENDENTES.md
+++ b/docs/db/SCHEMA_DECISOES_PENDENTES.md
@@ -982,7 +982,7 @@ Para o schema Drizzle/T-101, as seguintes convenções de tipos são obrigatóri
 | Datetime | `datetime`, `timestamp` | `TEXT` ISO8601 (`'2026-06-03T14:30:00Z'`) |
 | Money | `decimal`, `numeric`, `real` | `INTEGER` em **centavos** (evita rounding errors) |
 | Area | `decimal`, `real` | `INTEGER` em **centiares** (1 are = 100 m²) ou `TEXT` decimal com escala fixa |
-| Enum (ex: `tipo_cartorio`) | `enum` nativo Postgres | `TEXT` com `CHECK (col IN ('CRI','NOTAS','CIVIL','TRANSMISSAO','OUTRO'))` |
+| Enum (ex: `cri.tipo`) | `enum` nativo Postgres | `TEXT` com `CHECK (col IN ('CRI','OUTRO'))` |
 | UUID (operation_id) | n/a | `TEXT` (Drizzle gera UUID v4) |
 | Encrypted blob | n/a | `BLOB` (AES-256-GCM) — **N/A no v2** (Q4=A + Q5=REMOVER PII de Pessoa; v2 não armazena PII) |
 | Hash (cpf_hash) | n/a | `TEXT` (SHA-256 hex) — **N/A no v2** (sem PII para hashear) |

--- a/docs/db/SCHEMA_DECISOES_PENDENTES.md
+++ b/docs/db/SCHEMA_DECISOES_PENDENTES.md
@@ -1143,7 +1143,7 @@ CREATE UNIQUE INDEX uq_origem_fim_cadeia_origem
   WHERE origem_id IS NOT NULL;
 ```
 
-Drizzle não tem DSL pra `WHERE` em `uniqueIndex` ainda (issue #2456); workaround: `sql.raw` no migration ou Drizzle `index().where()`. Verificar na implementação T-101 qual a melhor forma.
+Drizzle 0.45+ suporta `uniqueIndex(...).where(...)` para partial UNIQUE; a migration T-101 usa essa DSL. Para versões anteriores, fallback via `sql.raw` no migration.
 
 ### Datas parciais (cartório tem data incompleta)
 
@@ -1164,18 +1164,21 @@ Cartórios frequentemente registram data incompleta ("15/06/1950" sem hora, ou "
 
 ### CHECK constraints
 
-Aplicar via migration Drizzle em todos os enums:
+Aplicar via migration Drizzle em todos os enums e constraints:
 
-- ~~`cri.tipo_cartorio` → `CHECK (tipo_cartorio IN ('CRI','NOTAS','CIVIL','TRANSMISSAO','OUTRO'))`~~ **REMOVIDO (round 3)**: a coluna `tipo_cartorio` não existe no ERD (`cri` tem só `nome`, `cns_codigo`, `cidade`, `uf`, `endereco`). Adicionar essa coluna é fora de escopo das decisões Q1-Q15 — `cri` é especificamente o cartório de registro de imóveis, não um cartório genérico.
+- `cri.tipo` → `CHECK (tipo IN ('CRI','OUTRO'))` (T-100)
 - `lancamento_tipo.tipo` → `CHECK (tipo IN ('inicio_matricula','registro','averbacao'))`
 - `documento.tipo` → `CHECK (tipo IN ('matricula','transcricao'))`
 - `origem.tipo` → `CHECK (tipo IN ('matricula','transcricao','fim_cadeia'))`
+- `origem.indice` → `CHECK (indice >= 0)`
 - `lancamento_pessoa.papel` → `CHECK (papel IN ('transmitente','adquirente','outorgante','outorgado','anuente','testemunha'))`
 - `audit_log.action` → `CHECK (action IN ('CREATE','EDIT','SOFT_DELETE','RESTORE','MOVE','ANNOTATE','EXPORT'))`
 - `imovel.arquivado` → `CHECK (arquivado IN (0,1))`
 - `imovel_documento.is_documento_atual` → `CHECK (is_documento_atual IN (0,1))`
 - `anotacao_versao.is_current` → `CHECK (is_current IN (0,1))`
-- `user.deleted_at IS NULL OR deleted_at GLOB '[0-9]*'` (data válida)
+- `lancamento.numero_lancamento` → `CHECK (numero_lancamento > 0)` (parcial: WHERE NOT NULL)
+- `lancamento_move_event.reason` → `CHECK (length(reason) > 0)` (Q12=D)
+- `v2_user.deleted_at IS NULL OR deleted_at GLOB '[0-9]*'` (data válida, opcional)
 
 > **Nota sobre Mermaid ERD (T4):** o .mmd (`erd-v2.mmd`) é **documentação visual**, NÃO schema canônico. Tipos `text` no Mermaid correspondem a `TEXT` no D1, mas a versão executável é a Drizzle migration (T-101). `UNIQUE_NOTE` é só annotation visual — partial UNIQUE indexes (`WHERE deleted_at IS NULL`), CHECK constraints, FTS5 sync triggers, e views (`v_lancamento_current_location`, `v_documento_orfao`) NÃO aparecem no .mmd; aplicar via migration Drizzle + SQL DDL. **Mermaid interpreta `--` e `|` em comentários como relações**, então CHECK constraints detalhados vão no .md, não no .mmd.
 

--- a/docs/db/SCHEMA_QUESTOES.md
+++ b/docs/db/SCHEMA_QUESTOES.md
@@ -1,7 +1,9 @@
-# Questoes abertas e decisoes pendentes (Schema Consolidado)
+# Questões detalhadas do schema (Q1–Q25)
 
-Este documento consolida pontos ambiguos, riscos e decisoes pendentes do schema.  
-Use-o para registrar respostas e alinhar o time.
+Este documento lista **perguntas técnicas e de coluna** levantadas durante a revisão cega do schema v2. As respostas estão em `docs/db/SCHEMA_RESPOSTAS.md`.
+
+> 📌 **Decisões de arquitetura de alto nível** (Q1–Q6: cascade, soft-delete, cardinalidade de fim de cadeia, criptografia, validação de CPF/CNPJ, visualização no React Flow) estão em `docs/db/SCHEMA_DECISOES_PENDENTES.md`. Não confunda os dois documentos — este aqui é o detalhamento, o outro é a arquitetura.
+
 Status: **resolvidas** em `docs/db/SCHEMA_RESPOSTAS.md`.
 
 Formato sugerido para responder cada item:

--- a/docs/db/SCHEMA_QUESTOES.md
+++ b/docs/db/SCHEMA_QUESTOES.md
@@ -2,7 +2,7 @@
 
 Este documento lista **perguntas técnicas e de coluna** levantadas durante a revisão cega do schema v2. As respostas estão em `docs/db/SCHEMA_RESPOSTAS.md`.
 
-> 📌 **Decisões de arquitetura de alto nível** (Q1–Q6: cascade, soft-delete, cardinalidade de fim de cadeia, criptografia, validação de CPF/CNPJ, visualização no React Flow) estão em `docs/db/SCHEMA_DECISOES_PENDENTES.md`. Não confunda os dois documentos — este aqui é o detalhamento, o outro é a arquitetura.
+> 📌 **Decisões de arquitetura de alto nível** (Q1–Q15 + Q11b: cascade, soft-delete, cardinalidade de fim de cadeia, criptografia, validação de CPF/CNPJ, visualização no React Flow, MOVE, delete compartilhado, etc.) estão em `docs/db/SCHEMA_DECISOES_PENDENTES.md`. Não confunda os dois documentos — este aqui é o detalhamento, o outro é a arquitetura.
 
 Status: **resolvidas** em `docs/db/SCHEMA_RESPOSTAS.md`.
 

--- a/docs/db/erd-v2-legend.md
+++ b/docs/db/erd-v2-legend.md
@@ -57,8 +57,7 @@ O formato e do tipo: `A ||--o{ B : rotulo`
   - Cada origem pertence a **um** lancamento.
   - Cada origem pode ter (zero ou um) `origem_fim_cadeia` independente (classificacao por origem).
 
-- `origem o|--o{ origem_fim_cadeia : "?"` (na verdade e 1:1)
-  - Ver: `origem ||--o| origem_fim_cadeia : fim_cadeia` — uma origem pode ter zero ou um registro de fim de cadeia.
+- `origem ||--o| origem_fim_cadeia : fim_cadeia (Q3=B)` — uma origem pode ter zero ou um registro de fim de cadeia (1:1 parcial).
 
 ## 3) Significado dos rotulos (texto nas linhas)
 

--- a/docs/db/erd-v2-legend.md
+++ b/docs/db/erd-v2-legend.md
@@ -4,7 +4,7 @@ Este diagrama mostra **tabelas** (caixas) e **relacionamentos** (linhas) entre e
 
 > **Decisoes de design** (Q1-Q15, Q11b, D1-D4, T1-T4) que ancoram este ERD: `docs/db/SCHEMA_DECISOES_PENDENTES.md`. **Schema canonico** (colunas, constraints, tipos SQLite/D1): **`docs/db/SCHEMA_CONSOLIDATED.md` ESTÁ SUPERSEDED — ver aviso no topo desse arquivo; usar `docs/db/SCHEMA_DECISOES_PENDENTES.md` + `erd-v2.mmd` como referência canônica até a migration T-101 ser aplicada**. **Critica completa do Codex gpt-5.5 (xhigh)**: `docs/db/CODEX_CRITIQUE_2026-06-03.md` (round 1) e `docs/db/CODEX_CRITIQUE_2026-06-03_ROUND2.md` (round 2) e triage round 3 em "Próximos passos" do decisions doc.
 >
-> **T4 — Mermaid NAO e schema.** O `.mmd` e documentacao visual. UNIQUE_NOTE, comentarios inline, e tipos no Mermaid nao sao enforcem em SQL. A versao canonica e a Drizzle migration (T-101) com partial UNIQUE indexes, CHECK constraints, FTS5 sync triggers, e views.
+> **T4 — Mermaid NAO e schema.** O `.mmd` e documentacao visual. UNIQUE_NOTE, comentarios inline, e tipos no Mermaid nao sao enforcem em SQL. A versao canonica e a Drizzle migration (T-101) com partial UNIQUE indexes, CHECK constraints, e views. FTS5 sync triggers sao **tarefa futura** (nao implementados em T-101).
 
 ## 1) O que e cada caixa (tabela)
 

--- a/docs/db/erd-v2-legend.md
+++ b/docs/db/erd-v2-legend.md
@@ -12,6 +12,7 @@ Este diagrama mostra **tabelas** (caixas) e **relacionamentos** (linhas) entre e
 - Dentro da caixa estao os **campos** (colunas) com seu tipo (`int`, `text`, `integer`).
 - `PK` = **Primary Key** (identificador unico da linha).
 - `FK` = **Foreign Key** (campo que aponta para outra tabela).
+- A entidade `v2_user` no ERD corresponde à tabela SQL `v2_user` (pesquisador). Há também uma tabela scaffold `users` (auth JWT) em `packages/api/drizzle/schema.ts` que não aparece neste diagrama de domínio.
 
 ### Tipos no ERD (convencao SQLite/D1 — ver Apêndice em SCHEMA_DECISOES_PENDENTES.md)
 

--- a/docs/db/erd-v2.mmd
+++ b/docs/db/erd-v2.mmd
@@ -7,11 +7,12 @@
 %% Nomes de entidade no .mmd vs SQL: a entidade `v2_user` é a tabela `v2_user` (pesquisador).
 %%   Há também uma tabela scaffold `users` (auth JWT) em schema.ts que NÃO aparece neste ERD de domínio.
 %% ============================================================================
-%% ⚠️ T4 — Mermaid NÃO é schema. UNIQUE_NOTE é só documentação visual.
-%%    A versão canônica é a Drizzle migration (T-101). Partial UNIQUE indexes
-%%    (`WHERE deleted_at IS NULL`), CHECK constraints, FTS5 sync triggers,
-%%    e a view v_lancamento_current_location (T2) NÃO aparecem no .mmd —
-%%    aplicar via migration Drizzle + SQL DDL.
+%% ⚠️ T4 — Mermaid NAO e schema. UNIQUE_NOTE e so documentacao visual.
+%%    A versao canonica e a Drizzle migration (T-101). Partial UNIQUE indexes
+%%    (`WHERE deleted_at IS NULL`), CHECK constraints, e views
+%%    (`v_lancamento_current_location`, `v_documento_orfao`) NAO aparecem no .mmd
+%%    — aplicar via migration Drizzle + SQL DDL.
+%%    FTS5 sync triggers sao tarefa futura (nao implementados em T-101).
 %% ============================================================================
 erDiagram
     cri ||--o{ imovel : "registra (fixo, Q11b=B)"
@@ -38,7 +39,7 @@ erDiagram
     audit_log o|--o{ lancamento_move_event : "registra (SET NULL on audit purge)"
     imovel ||--o{ tis_imovel : "vincula_TI"
     tis ||--o{ tis_imovel : "vincula_TI"
-    terra_indigena_referencia ||--o{ tis : "referencia"
+    terra_indigena_referencia o|--o{ tis : "referencia (opcional)"
 
     cri {
         int id PK

--- a/docs/db/erd-v2.mmd
+++ b/docs/db/erd-v2.mmd
@@ -4,6 +4,8 @@
 %% Convenções SQLite/D1: TEXT ISO8601 p/ datas, INTEGER 0/1 p/ bool, INTEGER centavos p/ money
 %% CHECK constraints vão via migration Drizzle (Mermaid interpreta -- e | em comentários)
 %% Soft-delete: deleted_at TEXT NULL em todas as tabelas relevantes (Q2=B)
+%% Nomes de entidade no .mmd vs SQL: a entidade `v2_user` é a tabela `v2_user` (pesquisador).
+%%   Há também uma tabela scaffold `users` (auth JWT) em schema.ts que NÃO aparece neste ERD de domínio.
 %% ============================================================================
 %% ⚠️ T4 — Mermaid NÃO é schema. UNIQUE_NOTE é só documentação visual.
 %%    A versão canônica é a Drizzle migration (T-101). Partial UNIQUE indexes
@@ -17,10 +19,10 @@ erDiagram
     imovel ||--o{ imovel_documento : "pertence (Q13=B, N:N)"
     documento ||--o{ imovel_documento : "pertence (Q13=B, N:N)"
     imovel_documento ||--o{ anotacao_versao : "anotado_em (Q9=C)"
-    user ||--o{ anotacao_versao : "autor_original (Q9=C, F1: imutavel, RESTRICT — autor nunca vira NULL, mesmo com LGPD do editor)"
-    user o|--o{ anotacao_versao : "created_by (D3, F1: editor, pode diferir do autor original, SET NULL)"
-    user o|--o{ lancamento_move_event : "moved_by (D3, user NAO pessoa, SET NULL)"
-    user o|--o{ audit_log : "actor (D3, user NAO pessoa, SET NULL on LGPD)"
+    v2_user ||--o{ anotacao_versao : "autor_original (Q9=C, F1: imutavel, RESTRICT — autor nunca vira NULL, mesmo com LGPD do editor)"
+    v2_user o|--o{ anotacao_versao : "created_by (D3, F1: editor, pode diferir do autor original, SET NULL)"
+    v2_user o|--o{ lancamento_move_event : "moved_by (D3, user NAO pessoa, SET NULL)"
+    v2_user o|--o{ audit_log : "actor (D3, user NAO pessoa, SET NULL on LGPD)"
     pessoa o|--o{ imovel : "proprietario (SET NULL se anonimizado LGPD, imovel preservado)"
     pessoa o|--o{ lancamento_pessoa : "participa (Q2=B, SET NULL on LGPD, nome_verbatim preservado)"
     lancamento ||--o{ lancamento_pessoa : "envolve (NOT NULL, CASCADE)"
@@ -52,9 +54,9 @@ erDiagram
         text UNIQUE_NOTE "D1: UNIQUE (cns_codigo) WHERE cns_codigo IS NOT NULL AND deleted_at IS NULL (partial UNIQUE). Duplicatas de nome aceitas (cidade tem 2 1o Cartorio)."
     }
 
-    user {
+    v2_user {
         int id PK
-        text email "UNIQUE, login do pesquisador"
+        text email "UNIQUE (parcial: WHERE deleted_at IS NULL), login do pesquisador"
         text nome "nome de exibicao do pesquisador"
         text created_at "ISO8601"
         text updated_at "ISO8601"
@@ -237,12 +239,15 @@ erDiagram
         integer area_centiares "em centiares"
         text estado
         text nome
+        text created_at "ISO8601"
+        text updated_at "ISO8601"
     }
 
     tis_imovel {
         int id PK
         int tis_id FK
         int imovel_id FK
+        text created_at "ISO8601"
         text UNIQUE_NOTE "UNIQUE (tis_id, imovel_id)"
     }
 
@@ -262,4 +267,6 @@ erDiagram
         text data_declarada
         text data_delimitada
         text data_em_estudo
+        text created_at "ISO8601"
+        text updated_at "ISO8601"
     }

--- a/docs/db/erd-v2.mmd
+++ b/docs/db/erd-v2.mmd
@@ -43,8 +43,9 @@ erDiagram
         text nome "1o Cartorio de Registro de Imoveis de Salvador"
         text cns_codigo "Cadastro Nacional de Serventia, TBD"
         text cidade
-        text uf "CHECK uf in 27 valores"
+        text uf "27 UFs, validado na app (sem CHECK no DB)"
         text endereco
+        text tipo "CHECK in (CRI, OUTRO), DEFAULT CRI (T-100)"
         text created_at "ISO8601"
         text updated_at "ISO8601"
         text deleted_at "soft-delete (Q2=B)"
@@ -133,8 +134,8 @@ erDiagram
     lancamento {
         int id PK
         text data "ISO8601"
-        integer valor_transacao "em CENTAVOS (evita rounding errors)"
-        integer area "em CENTIARES (1 are = 100 m2)"
+        integer valor_transacao_centavos "em CENTAVOS (evita rounding errors)"
+        integer area_centiares "em CENTIARES (1 are = 100 m2)"
         text detalhes
         text observacoes
         text data_cadastro
@@ -233,7 +234,7 @@ erDiagram
         text etnia
         text data_cadastro
         int terra_referencia_id FK
-        integer area "em centiares"
+        integer area_centiares "em centiares"
         text estado
         text nome
     }
@@ -252,7 +253,7 @@ erDiagram
         text etnia
         text estado
         text municipio
-        integer area_ha "em centiares (1 ha = 100 are = 10000 m2)"
+        integer area_ha_centiares "em centiares (1 ha = 100 are = 10000 m2)"
         text fase
         text modalidade
         text coordenacao_regional

--- a/docs/db/erd-v2.mmd
+++ b/docs/db/erd-v2.mmd
@@ -17,34 +17,33 @@ erDiagram
     imovel ||--o{ imovel_documento : "pertence (Q13=B, N:N)"
     documento ||--o{ imovel_documento : "pertence (Q13=B, N:N)"
     imovel_documento ||--o{ anotacao_versao : "anotado_em (Q9=C)"
-    user ||--o{ anotacao_versao : "autor_original (Q9=C, F1: imutavel, era pessoa)"
-    user ||--o{ anotacao_versao : "created_by (D3, F1: editor, pode diferir do autor original)"
-    user ||--o{ lancamento_move_event : "moved_by (D3, user NAO pessoa)"
-    user ||--o{ audit_log : "actor (D3, user NAO pessoa)"
-    pessoa ||--o{ imovel : "proprietario (pode ser NULL se anonimizado LGPD)"
-    pessoa ||--o{ lancamento_pessoa : "participa (Q2=B, nome_verbatim preservado)"
-    lancamento ||--o{ lancamento_pessoa : "envolve"
-    lancamento_tipo ||--o{ lancamento : "classifica (tipo_id, F3)"
-    documento ||--o{ lancamento : "gera"
+    user ||--o{ anotacao_versao : "autor_original (Q9=C, F1: imutavel, RESTRICT — autor nunca vira NULL, mesmo com LGPD do editor)"
+    user o|--o{ anotacao_versao : "created_by (D3, F1: editor, pode diferir do autor original, SET NULL)"
+    user o|--o{ lancamento_move_event : "moved_by (D3, user NAO pessoa, SET NULL)"
+    user o|--o{ audit_log : "actor (D3, user NAO pessoa, SET NULL on LGPD)"
+    pessoa o|--o{ imovel : "proprietario (SET NULL se anonimizado LGPD, imovel preservado)"
+    pessoa o|--o{ lancamento_pessoa : "participa (Q2=B, SET NULL on LGPD, nome_verbatim preservado)"
+    lancamento ||--o{ lancamento_pessoa : "envolve (NOT NULL, CASCADE)"
+    lancamento_tipo ||--o{ lancamento : "classifica (tipo_id, F3, NOT NULL, RESTRICT)"
+    documento o|--o{ lancamento : "gera (SET NULL on documento delete, L preservado orfao — Q7b=B)"
     documento o|--o{ origem : "origem_doc (opcional)"
-    lancamento ||--o{ origem : "possui (1:N, Q3=B)"
-    origem ||--o| origem_fim_cadeia : "fim_cadeia (Q3=B, 1:1 por origem)"
-    cri o|--o{ origem : "cri_origem (Q11b=A, este campo é o cri_origem_id)"
-    lancamento ||--o{ lancamento_move_event : "movido (Q14=B, append-only)"
-    documento ||--o{ lancamento_move_event : "from_doc"
-    documento ||--o{ lancamento_move_event : "to_doc"
-    audit_log ||--o{ lancamento_move_event : "registra"
+    lancamento ||--o{ origem : "possui (1:N, Q3=B, NOT NULL, RESTRICT)"
+    origem ||--o| origem_fim_cadeia : "fim_cadeia (Q3=B, 1:1 por origem, CASCADE)"
+    cri ||--o{ origem : "cri_origem (Q11b=A, este campo é o cri_origem_id, RESTRICT — cadeia forense protegida, Q3 round-3)"
+    lancamento ||--o{ lancamento_move_event : "movido (Q14=B, append-only, NOT NULL, RESTRICT)"
+    documento o|--o{ lancamento_move_event : "from_doc (SET NULL)"
+    documento o|--o{ lancamento_move_event : "to_doc (SET NULL)"
+    audit_log o|--o{ lancamento_move_event : "registra (SET NULL on audit purge)"
     imovel ||--o{ tis_imovel : "vincula_TI"
     tis ||--o{ tis_imovel : "vincula_TI"
     terra_indigena_referencia ||--o{ tis : "referencia"
 
     cri {
         int id PK
-        text tipo "CRI ou OUTRO (CHECK tipo IN (CRI,OUTRO), DEFAULT CRI). T-100: parity com Django Cartorios.tipo"
         text nome "1o Cartorio de Registro de Imoveis de Salvador"
         text cns_codigo "Cadastro Nacional de Serventia, TBD"
         text cidade
-        text uf "app-layer CHECK (27 UFs). DB: plain text, sem CHECK constraint"
+        text uf "CHECK uf in 27 valores"
         text endereco
         text created_at "ISO8601"
         text updated_at "ISO8601"
@@ -134,8 +133,8 @@ erDiagram
     lancamento {
         int id PK
         text data "ISO8601"
-        integer valor_transacao_centavos "em CENTAVOS (evita rounding errors). DB col: valor_transacao_centavos"
-        integer area_centiares "em CENTIARES (1 are = 100 m2). DB col: area_centiares"
+        integer valor_transacao "em CENTAVOS (evita rounding errors)"
+        integer area "em CENTIARES (1 are = 100 m2)"
         text detalhes
         text observacoes
         text data_cadastro
@@ -168,7 +167,7 @@ erDiagram
     origem {
         int id PK
         int lancamento_id FK
-        int cri_id FK "CRI de origem (Q11b=A: este campo ja e o cri_origem_id)"
+        int cri_id FK "CRI de origem (Q11b=A: este campo ja e o cri_origem_id, RESTRICT)"
         int documento_id FK "opcional, NULL se tipo=fim_cadeia"
         int indice "0, 1, 2..., CHECK >= 0, contiguo por lancamento"
         text tipo "CHECK in (matricula, transcricao, fim_cadeia)"
@@ -178,8 +177,8 @@ erDiagram
         text folha
         text data
         text observacoes
-        text created_at "ISO8601"
-        text deleted_at "soft-delete (Q2=B)"
+        text created_at
+        text deleted_at "soft-delete (Q2=B). Origem preserva evidencia de divergencia entre certidoes (Q3 round-3)"
         text UNIQUE_NOTE "UNIQUE (lancamento_id, indice)"
     }
 
@@ -234,7 +233,7 @@ erDiagram
         text etnia
         text data_cadastro
         int terra_referencia_id FK
-        integer area_centiares "em centiares (1 are = 100 m2). DB col: area_centiares"
+        integer area "em centiares"
         text estado
         text nome
     }
@@ -253,7 +252,7 @@ erDiagram
         text etnia
         text estado
         text municipio
-        integer area_ha_centiares "em centiares. DB col: area_ha_centiares"
+        integer area_ha "em centiares (1 ha = 100 are = 10000 m2)"
         text fase
         text modalidade
         text coordenacao_regional


### PR DESCRIPTION
## Summary

Syncs the final schema architecture decisions (Q1-Q15 + Q11b) from the stale `feat/t-001-schema-decisions-v2` worktree into `v2`, and updates surrounding docs to prevent the confusion that the questions were still unanswered.

## Changes

- `docs/db/SCHEMA_DECISOES_PENDENTES.md` -- pulled final decisions from `t-001-v2`; renamed title to clarify it is the canonical architecture-decision doc; added cross-references to `SCHEMA_QUESTOES.md` / `SCHEMA_RESPOSTAS.md`.
- `docs/db/SCHEMA_QUESTOES.md` -- clarified scope (detailed column-level questions Q1-Q25) and cross-linked `SCHEMA_DECISOES_PENDENTES.md` for architecture decisions.
- `docs/TASKS.md` -- closed Phase 0 explicitly and cross-linked the three schema docs.
- `docs/db/erd-v2-legend.md` / `erd-v2.mmd` -- synced with final decisions.

## Why a new branch?

The original `feat/t-001-schema-decisions-v2` worktree is based on an old `v2` tip and rebasing produced merge conflicts. To avoid a messy history, this branch was created fresh from current `origin/v2` and carries only the relevant doc/ERD changes.

## Verification

- `docs/` changes only; no source/schema code changes.
- `pnpm -C packages/api run db:generate` still produces a clean migration (schema unchanged).

Closes the doc-confusion part of the schema-decision work.
