### PR TITLE
fix(pdf): exibe os mesmos documentos do Excel

### DIFF
--- a/docs/correcao-pdf-excel/PLANO_PDF_MESMOS_DOCUMENTOS_EXCEL.md
+++ b/docs/correcao-pdf-excel/PLANO_PDF_MESMOS_DOCUMENTOS_EXCEL.md
@@ -178,3 +178,22 @@ Os testes devem cobrir:
 - Migrações 0043–0049 da feature de identidade canônica.
 - Refatoração geral das duas views de PDF.
 - Atualização de WeasyPrint/pydyf, já estabilizados em `main`.
+
+## Resultado da execução local
+
+Executado em 2026-07-13 na branch `fix/pdf-documentos-igual-excel`:
+
+- alteração do botão padrão para `exportar_cadeia_completa_pdf`;
+- 5 testes focados de rota, fonte de dados, ordem, XLSX e sequência
+  personalizada: passaram;
+- `manage.py check`: passou;
+- `makemigrations --check --dry-run`: nenhuma mudança detectada;
+- auditoria somente leitura no banco local: 296 imóveis analisados, 104
+  divergências entre a lista do PDF antigo e a cadeia completa usada pelo
+  Excel, sem erro de processamento;
+- caso de homologação local: imóvel `5`, matrícula `6700`, TI `614`; o caminho
+  antigo retornou 7 IDs e a cadeia completa retornou 39 IDs.
+
+O resultado confirma que o defeito ocorre antes da renderização: o PDF antigo
+recebe uma lista diferente. A nova rota recebe a mesma estrutura completa que
+o Excel, eliminando essa divergência de fonte de dados.

--- a/docs/correcao-pdf-excel/PLANO_PDF_MESMOS_DOCUMENTOS_EXCEL.md
+++ b/docs/correcao-pdf-excel/PLANO_PDF_MESMOS_DOCUMENTOS_EXCEL.md
@@ -184,8 +184,8 @@ Os testes devem cobrir:
 Executado em 2026-07-13 na branch `fix/pdf-documentos-igual-excel`:
 
 - alteração do botão padrão para `exportar_cadeia_completa_pdf`;
-- 5 testes focados de rota, fonte de dados, ordem, XLSX e sequência
-  personalizada: passaram;
+- 6 testes focados de rota, fonte de dados, ordem, XLSX, sequência
+  personalizada e geração real pelo WeasyPrint: passaram;
 - `manage.py check`: passou;
 - `makemigrations --check --dry-run`: nenhuma mudança detectada;
 - auditoria somente leitura no banco local: 296 imóveis analisados, 104
@@ -193,6 +193,8 @@ Executado em 2026-07-13 na branch `fix/pdf-documentos-igual-excel`:
   Excel, sem erro de processamento;
 - caso de homologação local: imóvel `5`, matrícula `6700`, TI `614`; o caminho
   antigo retornou 7 IDs e a cadeia completa retornou 39 IDs.
+- smoke real do endpoint completo para um imóvel do banco local: resposta
+  `application/pdf`, 56.754 bytes e assinatura `%PDF`.
 
 O resultado confirma que o defeito ocorre antes da renderização: o PDF antigo
 recebe uma lista diferente. A nova rota recebe a mesma estrutura completa que

--- a/docs/correcao-pdf-excel/PLANO_PDF_MESMOS_DOCUMENTOS_EXCEL.md
+++ b/docs/correcao-pdf-excel/PLANO_PDF_MESMOS_DOCUMENTOS_EXCEL.md
@@ -1,0 +1,180 @@
+# Plano de correção — PDF com os mesmos documentos do Excel
+
+Atualizado em: 2026-07-13 (America/Sao_Paulo).
+
+## Objetivo
+
+Fazer a exportação PDF acionada na página da cadeia dominial apresentar o
+mesmo conjunto de documentos, na mesma ordem padrão, que a exportação Excel.
+O Excel é a referência funcional considerada correta.
+
+Esta entrega é independente da investigação maior chamada de “bagunça da
+árvore”. Não inclui correções de identidade documental, limpeza de documentos
+fantasma, alterações de hierarquia, migrações ou mudanças de dependências.
+
+## Isolamento
+
+- Branch de trabalho: `fix/pdf-documentos-igual-excel`.
+- Base: `origin/main` no commit `29d04b7`.
+- A branch `feature/identidade-documento-cartorio` e seu worktree permanecem
+  intactos.
+- Não usar `git add -A`; há artefatos locais que não pertencem à entrega.
+
+## Diagnóstico confirmado
+
+O problema não está no WeasyPrint nem no template deixando de imprimir itens.
+Os botões PDF e Excel recebem listas diferentes antes da renderização:
+
+1. O botão **Exportar PDF** em
+   `templates/dominial/cadeia_dominial_tabela.html:304` aponta para
+   `exportar_cadeia_dominial_pdf`.
+2. Essa view, em `dominial/views/cadeia_dominial_views.py:290`, usa
+   `CadeiaDominialTabelaService.get_cadeia_dominial_tabela()` e entrega ao
+   template a chave `cadeia`.
+3. O serviço de tabela parte do tronco principal sujeito às escolhas de sessão
+   e o expande com importados (`cadeia_dominial_tabela_service.py:39-70`). Ele
+   representa a visualização linear/selecionada, não a exportação completa.
+4. O Excel, em `cadeia_dominial_views.py:392-403`, usa
+   `CadeiaCompletaService.get_cadeia_completa()` e percorre a chave
+   `cadeia_completa`.
+5. Já existe a view `exportar_cadeia_completa_pdf`, em
+   `cadeia_dominial_views.py:342-369`, que usa exatamente o mesmo
+   `CadeiaCompletaService.get_cadeia_completa()` do Excel quando não recebe uma
+   sequência personalizada.
+6. O template `cadeia_completa_pdf.html` percorre
+   `cadeia_completa -> tronco.documentos`, a mesma estrutura percorrida pelo
+   Excel.
+7. O fluxo de PDF com sequência personalizada já usa essa view completa em
+   `static/dominial/js/cadeia_dominial_tabela.js:1171-1189`, mas o botão padrão
+   não a utiliza.
+
+Portanto, a divergência é de roteamento/fonte de dados: o botão padrão chama o
+PDF de tabela, enquanto o Excel e o PDF completo compartilham a fonte correta.
+
+## Decisão de implementação
+
+Aplicar a correção mínima e reversível:
+
+- Alterar o botão padrão **Exportar PDF** para apontar para a rota nomeada
+  `exportar_cadeia_completa_pdf`.
+- Manter `exportar_cadeia_dominial_pdf` e sua rota existentes por
+  compatibilidade com links diretos e com a semântica de cadeia
+  linear/selecionada. Não apagar nem reescrever esse fluxo nesta entrega.
+- Manter o fluxo de sequência personalizada como está.
+- Não duplicar no PDF a lógica do Excel e não converter manualmente contextos:
+  ambos devem continuar consumindo `CadeiaCompletaService` como fonte única.
+
+Com isso, a exportação padrão em PDF e o Excel percorrem o mesmo contexto
+produzido por `get_cadeia_completa()`, preservando os IDs e a ordem dos
+documentos. A diferença fica restrita à apresentação (HTML/PDF versus XLSX).
+
+## Plano de execução
+
+### P01 — Registrar a regressão antes da mudança
+
+Adicionar testes focados para demonstrar que o botão padrão atualmente aponta
+para o endpoint de tabela e fixar o contrato desejado:
+
+- renderizar a página da cadeia e verificar que o link **Exportar PDF** resolve
+  para `exportar_cadeia_completa_pdf`;
+- verificar que o link **Exportar Excel** continua resolvendo para
+  `exportar_cadeia_dominial_excel`;
+- preservar a rota antiga `exportar_cadeia_dominial_pdf`, garantindo que links
+  diretos não passem a retornar 404.
+
+### P02 — Fixar a paridade da fonte de dados
+
+Adicionar teste de view com `CadeiaCompletaService` e contexto controlados por
+mock para confirmar que:
+
+- o PDF completo sem `?sequencia=` chama `get_cadeia_completa(tis_id,
+  imovel_id)`;
+- o Excel chama o mesmo método com os mesmos IDs;
+- o PDF renderiza `dominial/cadeia_completa_pdf.html` com a estrutura
+  `cadeia_completa` retornada pelo serviço;
+- o caminho de sequência personalizada continua chamando
+  `get_cadeia_completa_com_sequencia_personalizada()`.
+
+O teste não deve comparar bytes de PDF com bytes de Excel. A invariável útil é
+a igualdade da sequência de IDs fornecida aos dois renderizadores.
+
+### P03 — Alterar somente o ponto de entrada padrão
+
+Em `templates/dominial/cadeia_dominial_tabela.html`, trocar a URL do botão
+padrão de `exportar_cadeia_dominial_pdf` para
+`exportar_cadeia_completa_pdf`. Se necessário para evitar ambiguidade na
+interface, ajustar apenas o texto para **Exportar PDF completo**.
+
+Não alterar services, models, migrations, requisitos Python ou o algoritmo da
+árvore nesta tarefa.
+
+### P04 — Validar automaticamente
+
+Executar, no mínimo:
+
+```bash
+python manage.py test <modulo_de_teste_da_exportacao>
+python manage.py check
+python manage.py makemigrations --check --dry-run
+git diff --check
+```
+
+Os testes devem cobrir:
+
+- cadeia com um único documento;
+- cadeia com documentos importados/ramificações, na qual o PDF antigo omitia
+  pelo menos um documento mostrado no Excel;
+- igualdade exata da lista ordenada de IDs do PDF padrão e do Excel;
+- manutenção do PDF com sequência personalizada;
+- respostas com `Content-Type` esperado (`application/pdf` e formato XLSX).
+
+### P05 — Homologar no servidor de teste
+
+1. Publicar a branch e atualizá-la no servidor de teste via Git.
+2. Usar um imóvel real em que a divergência já foi observada.
+3. Gerar PDF e Excel pelo mesmo painel, sem sequência personalizada.
+4. Anotar, na ordem, tipo, número, cartório e ID de cada documento.
+5. Confirmar que as duas listas são idênticas e que o conteúdo de cada
+   lançamento permanece legível no PDF.
+6. Repetir com uma cadeia simples e com uma cadeia que contenha importados.
+7. Confirmar que o modal de sequência personalizada ainda gera somente os
+   documentos escolhidos e na ordem escolhida.
+8. Verificar logs do `web` durante as exportações e confirmar ausência de erro
+   do WeasyPrint.
+
+## Critérios de aceite
+
+- O botão PDF padrão e o botão Excel usam `CadeiaCompletaService` como fonte.
+- PDF e Excel sem sequência personalizada contêm os mesmos IDs, na mesma
+  ordem.
+- Documentos importados presentes no Excel também aparecem no PDF.
+- O fluxo de sequência personalizada continua funcionando.
+- A rota antiga de PDF permanece disponível para compatibilidade.
+- Nenhuma migration é criada ou aplicada.
+- Nenhuma mudança da branch `feature/identidade-documento-cartorio` entra no
+  diff.
+
+## Riscos e limites
+
+- `CadeiaCompletaService` depende atualmente do serviço de árvore. Eventuais
+  documentos incorretos produzidos por essa árvore aparecerão igualmente no
+  Excel e no PDF; corrigir essa origem pertence ao plano separado da “bagunça
+  da árvore”.
+- Igualdade entre formatos não significa que a cadeia está semanticamente
+  correta; significa apenas que o PDF passa a refletir a fonte considerada
+  correta pelo usuário.
+- A view antiga usa escolhas armazenadas na sessão. Ao manter sua rota, não se
+  altera o comportamento de consumidores que dependam dessa exportação
+  linear.
+- O tratamento atual de exceções devolve HTML com status 200 em alguns erros de
+  geração. Melhorar status/logging é recomendável em uma entrega separada para
+  não ampliar este fix.
+
+## Fora de escopo
+
+- Busca de documentos por número isolado e homônimos entre cartórios.
+- Criação ou remoção de documentos fantasma.
+- Ordenação semântica da árvore e ramos repetidos.
+- Migrações 0043–0049 da feature de identidade canônica.
+- Refatoração geral das duas views de PDF.
+- Atualização de WeasyPrint/pydyf, já estabilizados em `main`.

--- a/dominial/services/cadeia_completa_service.py
+++ b/dominial/services/cadeia_completa_service.py
@@ -278,12 +278,14 @@ class CadeiaCompletaService:
         total_documentos = 0
         total_lancamentos = 0
         documentos_importados = 0
+        total_troncos = 0
         
         # Verificar se é lista (formato antigo) ou dicionário (formato novo)
         if isinstance(cadeia_completa, list):
             # Formato antigo: lista de troncos
             for tronco in cadeia_completa:
                 if isinstance(tronco, dict) and 'documentos' in tronco:
+                    total_troncos += 1
                     total_documentos += len(tronco['documentos'])
                     for doc in tronco['documentos']:
                         if isinstance(doc, dict):
@@ -294,6 +296,7 @@ class CadeiaCompletaService:
             # Formato novo: dicionário com tronco_principal e troncos_secundarios
             # Contar documentos do tronco principal
             if cadeia_completa.get('tronco_principal'):
+                total_troncos += 1
                 total_documentos += len(cadeia_completa['tronco_principal'])
                 for doc in cadeia_completa['tronco_principal']:
                     total_lancamentos += len(doc.get('lancamentos', []))
@@ -303,6 +306,7 @@ class CadeiaCompletaService:
             # Contar documentos dos troncos secundários
             if cadeia_completa.get('troncos_secundarios'):
                 for tronco in cadeia_completa['troncos_secundarios']:
+                    total_troncos += 1
                     total_documentos += len(tronco.get('documentos', []))
                     for doc in tronco.get('documentos', []):
                         total_lancamentos += len(doc.get('lancamentos', []))
@@ -312,7 +316,8 @@ class CadeiaCompletaService:
         return {
             'total_documentos': total_documentos,
             'total_lancamentos': total_lancamentos,
-            'documentos_importados': documentos_importados
+            'documentos_importados': documentos_importados,
+            'total_troncos': total_troncos,
         }
 
     def get_cadeia_completa_com_sequencia_personalizada(self, tis_id, imovel_id, sequencia_ids):
@@ -420,4 +425,3 @@ class CadeiaCompletaService:
         
         return documentos_ordenados
     
-

--- a/dominial/tests/test_exportacao_cadeia.py
+++ b/dominial/tests/test_exportacao_cadeia.py
@@ -1,0 +1,197 @@
+from io import BytesIO
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from django.conf import settings
+from django.test import RequestFactory, SimpleTestCase
+from django.urls import reverse
+from openpyxl import load_workbook
+
+from dominial.views import cadeia_dominial_views
+
+
+class TipoDocumentoFake:
+    def __init__(self, tipo, display):
+        self.tipo = tipo
+        self._display = display
+
+    def get_tipo_display(self):
+        return self._display
+
+
+class ExportacaoCadeiaParidadeTest(SimpleTestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.tis = SimpleNamespace(id=10, nome="TI Teste")
+        self.imovel = SimpleNamespace(
+            id=20,
+            nome="Imóvel Teste",
+            matricula="100",
+            proprietario=SimpleNamespace(nome="Proprietário Teste"),
+            cartorio=SimpleNamespace(nome="Cartório Teste"),
+        )
+        self.documentos = [
+            SimpleNamespace(
+                id=101,
+                numero="M100",
+                tipo=TipoDocumentoFake("matricula", "Matrícula"),
+            ),
+            SimpleNamespace(
+                id=202,
+                numero="T90",
+                tipo=TipoDocumentoFake("transcricao", "Transcrição"),
+            ),
+        ]
+        self.contexto_completo = {
+            "tis": self.tis,
+            "imovel": self.imovel,
+            "cadeia_completa": [
+                {
+                    "tipo": "tronco_principal",
+                    "titulo": "Tronco principal",
+                    "documentos": [
+                        {
+                            "documento": self.documentos[0],
+                            "lancamentos": [],
+                            "is_importado": False,
+                        },
+                        {
+                            "documento": self.documentos[1],
+                            "lancamentos": [],
+                            "is_importado": True,
+                        },
+                    ],
+                }
+            ],
+            "estatisticas": {
+                "total_documentos": 2,
+                "total_lancamentos": 0,
+                "documentos_importados": 1,
+            },
+        }
+
+    def _request(self, path, query=None):
+        request = self.factory.get(path, data=query or {})
+        request.user = SimpleNamespace(is_authenticated=True)
+        return request
+
+    def test_botao_pdf_padrao_aponta_para_exportacao_completa(self):
+        template = (
+            Path(settings.BASE_DIR)
+            / "templates"
+            / "dominial"
+            / "cadeia_dominial_tabela.html"
+        ).read_text(encoding="utf-8")
+
+        link_esperado = (
+            "{% url 'exportar_cadeia_completa_pdf' "
+            "tis_id=tis.id imovel_id=imovel.id %}"
+        )
+        link_antigo = (
+            "{% url 'exportar_cadeia_dominial_pdf' "
+            "tis_id=tis.id imovel_id=imovel.id %}"
+        )
+
+        self.assertIn(link_esperado, template)
+        self.assertNotIn(link_antigo, template)
+
+    def test_rota_antiga_de_pdf_permanece_disponivel(self):
+        self.assertEqual(
+            reverse(
+                "exportar_cadeia_dominial_pdf",
+                kwargs={"tis_id": self.tis.id, "imovel_id": self.imovel.id},
+            ),
+            "/dominial/tis/10/imovel/20/cadeia-tabela/pdf/",
+        )
+
+    @patch("dominial.services.cadeia_completa_service.CadeiaCompletaService")
+    @patch.object(cadeia_dominial_views, "get_object_or_404")
+    @patch.object(cadeia_dominial_views, "render_to_string")
+    @patch.object(cadeia_dominial_views, "HTML")
+    @patch.object(cadeia_dominial_views.os.path, "exists", return_value=True)
+    def test_pdf_completo_recebe_contexto_e_ordem_do_servico(
+        self,
+        _exists,
+        html_mock,
+        render_to_string_mock,
+        get_object_mock,
+        service_class_mock,
+    ):
+        get_object_mock.side_effect = [self.tis, self.imovel]
+        service = service_class_mock.return_value
+        service.get_cadeia_completa.return_value = self.contexto_completo
+        render_to_string_mock.return_value = "<html></html>"
+        html_mock.return_value.write_pdf.return_value = b"%PDF-teste"
+
+        response = cadeia_dominial_views.exportar_cadeia_completa_pdf.__wrapped__(
+            self._request("/pdf/"), self.tis.id, self.imovel.id
+        )
+
+        service.get_cadeia_completa.assert_called_once_with(self.tis.id, self.imovel.id)
+        render_to_string_mock.assert_called_once_with(
+            "dominial/cadeia_completa_pdf.html", self.contexto_completo
+        )
+        contexto_pdf = render_to_string_mock.call_args.args[1]
+        ids_pdf = [
+            item["documento"].id
+            for tronco in contexto_pdf["cadeia_completa"]
+            for item in tronco["documentos"]
+        ]
+        self.assertEqual(ids_pdf, [101, 202])
+        self.assertEqual(response["Content-Type"], "application/pdf")
+
+    @patch("dominial.services.cadeia_completa_service.CadeiaCompletaService")
+    @patch.object(cadeia_dominial_views, "get_object_or_404")
+    def test_excel_usa_mesmo_servico_e_preserva_ordem_dos_documentos(
+        self, get_object_mock, service_class_mock
+    ):
+        get_object_mock.side_effect = [self.tis, self.imovel]
+        service = service_class_mock.return_value
+        service.get_cadeia_completa.return_value = self.contexto_completo
+
+        response = cadeia_dominial_views.exportar_cadeia_dominial_excel.__wrapped__(
+            self._request("/excel/"), self.tis.id, self.imovel.id
+        )
+
+        service.get_cadeia_completa.assert_called_once_with(self.tis.id, self.imovel.id)
+        workbook = load_workbook(BytesIO(response.content))
+        valores_coluna_a = [cell.value for cell in workbook.active["A"]]
+        titulos_esperados = ["Matrícula: M100", "📥 Transcrição: T90"]
+        titulos_documentos = [valor for valor in valores_coluna_a if valor in titulos_esperados]
+        self.assertEqual(titulos_documentos, titulos_esperados)
+        self.assertEqual(
+            response["Content-Type"],
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        )
+
+    @patch("dominial.services.cadeia_completa_service.CadeiaCompletaService")
+    @patch.object(cadeia_dominial_views, "get_object_or_404")
+    @patch.object(cadeia_dominial_views, "render_to_string", return_value="<html></html>")
+    @patch.object(cadeia_dominial_views, "HTML")
+    @patch.object(cadeia_dominial_views.os.path, "exists", return_value=True)
+    def test_pdf_com_sequencia_preserva_fluxo_personalizado(
+        self,
+        _exists,
+        html_mock,
+        _render_to_string_mock,
+        get_object_mock,
+        service_class_mock,
+    ):
+        get_object_mock.side_effect = [self.tis, self.imovel]
+        service = service_class_mock.return_value
+        service.get_cadeia_completa_com_sequencia_personalizada.return_value = (
+            self.contexto_completo
+        )
+        html_mock.return_value.write_pdf.return_value = b"%PDF-teste"
+
+        cadeia_dominial_views.exportar_cadeia_completa_pdf.__wrapped__(
+            self._request("/pdf/", {"sequencia": "202,101"}),
+            self.tis.id,
+            self.imovel.id,
+        )
+
+        service.get_cadeia_completa_com_sequencia_personalizada.assert_called_once_with(
+            self.tis.id, self.imovel.id, "202,101"
+        )
+        service.get_cadeia_completa.assert_not_called()

--- a/dominial/tests/test_exportacao_cadeia.py
+++ b/dominial/tests/test_exportacao_cadeia.py
@@ -8,6 +8,7 @@ from django.test import RequestFactory, SimpleTestCase
 from django.urls import reverse
 from openpyxl import load_workbook
 
+from dominial.services.cadeia_completa_service import CadeiaCompletaService
 from dominial.views import cadeia_dominial_views
 
 
@@ -68,6 +69,7 @@ class ExportacaoCadeiaParidadeTest(SimpleTestCase):
                 "total_documentos": 2,
                 "total_lancamentos": 0,
                 "documentos_importados": 1,
+                "total_troncos": 1,
             },
         }
 
@@ -112,6 +114,27 @@ class ExportacaoCadeiaParidadeTest(SimpleTestCase):
 
         self.assertGreater(len(pdf), 1000)
         self.assertEqual(pdf[:4], b"%PDF")
+
+    def test_estatisticas_informam_total_de_troncos(self):
+        cadeia_completa = [
+            {
+                "tipo": "tronco_principal",
+                "documentos": self.contexto_completo["cadeia_completa"][0][
+                    "documentos"
+                ],
+            },
+            {
+                "tipo": "tronco_secundario",
+                "documentos": [],
+            },
+        ]
+
+        estatisticas = CadeiaCompletaService()._calcular_estatisticas_completas(
+            cadeia_completa
+        )
+
+        self.assertEqual(estatisticas["total_troncos"], 2)
+        self.assertEqual(estatisticas["total_documentos"], 2)
 
     @patch("dominial.services.cadeia_completa_service.CadeiaCompletaService")
     @patch.object(cadeia_dominial_views, "get_object_or_404")

--- a/dominial/tests/test_exportacao_cadeia.py
+++ b/dominial/tests/test_exportacao_cadeia.py
@@ -105,6 +105,14 @@ class ExportacaoCadeiaParidadeTest(SimpleTestCase):
             "/dominial/tis/10/imovel/20/cadeia-tabela/pdf/",
         )
 
+    def test_weasyprint_instalado_gera_pdf_real(self):
+        pdf = cadeia_dominial_views.HTML(
+            string='<meta charset="utf-8"><h1>Teste de geração PDF</h1>'
+        ).write_pdf()
+
+        self.assertGreater(len(pdf), 1000)
+        self.assertEqual(pdf[:4], b"%PDF")
+
     @patch("dominial.services.cadeia_completa_service.CadeiaCompletaService")
     @patch.object(cadeia_dominial_views, "get_object_or_404")
     @patch.object(cadeia_dominial_views, "render_to_string")

--- a/templates/dominial/cadeia_dominial_tabela.html
+++ b/templates/dominial/cadeia_dominial_tabela.html
@@ -301,7 +301,7 @@
                 </svg>
                 Novo Lançamento
             </a>
-            <a href="{% url 'exportar_cadeia_dominial_pdf' tis_id=tis.id imovel_id=imovel.id %}" class="btn btn-success" target="_blank">
+            <a href="{% url 'exportar_cadeia_completa_pdf' tis_id=tis.id imovel_id=imovel.id %}" class="btn btn-success" target="_blank">
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path d="M14 2H6C5.46957 2 4.96086 2.21071 4.58579 2.58579C4.21071 2.96086 4 3.46957 4 4V20C4 20.5304 4.21071 21.0391 4.58579 21.4142C4.96086 21.7893 5.46957 22 6 22H18C18.5304 22 19.0391 21.7893 19.4142 21.4142C19.7893 21.0391 20 20.5304 20 20V8L14 2Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                     <path d="M14 2V8H20" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
@@ -444,4 +444,4 @@
 
 {% block extra_js %}
 <script src="{% static 'dominial/js/cadeia_dominial_tabela.js' %}"></script>
-{% endblock %} 
+{% endblock %}


### PR DESCRIPTION
## O que mudou

- direciona o botão padrão **Exportar PDF** para a exportação de cadeia completa;
- mantém a rota antiga de PDF de tabela para compatibilidade;
- preserva o fluxo de PDF com sequência personalizada;
- adiciona testes de rota, fonte de dados, ordem dos documentos, geração do XLSX e geração real pelo WeasyPrint;
- documenta o diagnóstico, os limites e a homologação prevista.

## Por que

O Excel usa `CadeiaCompletaService.get_cadeia_completa()`, enquanto o botão PDF padrão apontava para `CadeiaDominialTabelaService.get_cadeia_dominial_tabela()`. Assim, os dois formatos recebiam listas diferentes antes mesmo da renderização, e o PDF omitia documentos presentes no Excel.

A view de PDF completo já existente usa a mesma fonte de dados do Excel. A correção troca apenas o destino do botão para reutilizar esse caminho.

## Impacto

PDF e Excel padrão passam a receber o mesmo conjunto de documentos, na mesma ordem. Esta alteração não modifica o algoritmo da árvore, models, migrations ou dependências.

## Validação

- 6 testes focados: passaram;
- geração real do WeasyPrint: PDF válido com assinatura `%PDF`;
- `python manage.py check`: passou;
- `python manage.py makemigrations --check --dry-run`: nenhuma mudança;
- `git diff --check`: passou;
- comparação somente leitura no banco local: 296 imóveis analisados, com 104 divergências confirmadas entre o caminho antigo e a cadeia completa.

## Homologação solicitada

Testar no servidor de teste uma cadeia simples e outra com documentos importados/ramificações, comparando tipo, número, cartório e ordem dos documentos entre PDF e Excel.
