### PR TITLE
fix(arvore): corrige duplicação de cards e cruzamento de linhas na árvore D3

### DIFF
--- a/static/dominial/js/cadeia_dominial_d3.js
+++ b/static/dominial/js/cadeia_dominial_d3.js
@@ -218,6 +218,21 @@ function converterParaArvoreD3(data) {
     let iteracoes = 0;
     const limiteIteracoes = data.documentos.length * data.conexoes.length + data.documentos.length;
 
+    // Impede que uma citação cíclica (ex.: A cita B e B cita A, direta ou
+    // indiretamente) vire uma aresta primária -- senão docMap[X].children
+    // pode acabar contendo, direta ou indiretamente, o próprio X, e a
+    // recursão em ordenarFilhosPorNumeroDesc/d3.hierarchy nunca termina.
+    function criariCiclo(candidatoPai, alvo) {
+        let atual = candidatoPai;
+        let passos = 0;
+        while (atual !== undefined) {
+            if (atual === alvo) return true;
+            if (++passos > data.documentos.length) return true;
+            atual = paiPrimario.get(atual);
+        }
+        return false;
+    }
+
     while (fila.length > 0) {
         if (++iteracoes > limiteIteracoes) {
             console.warn('DEBUG: possível ciclo nas conexões, interrompendo cálculo de profundidade');
@@ -226,6 +241,8 @@ function converterParaArvoreD3(data) {
         const atual = fila.shift();
         (conexoesPorFrom.get(atual) || []).forEach(con => {
             if (!docMap[con.to]) return;
+            if (con.to === raiz.numero) return; // a raiz nunca recebe pai primário
+            if (criariCiclo(atual, con.to)) return;
             const novaProfundidade = profundidade.get(atual) + 1;
             if (!profundidade.has(con.to) || novaProfundidade > profundidade.get(con.to)) {
                 profundidade.set(con.to, novaProfundidade);
@@ -422,15 +439,23 @@ function corrigirSobreposicoes(root) {
 // Função otimizada: Aplicar espaçamento adicional para evitar sobreposições
 function ajustarPosicoesPorNivel(root) {
     // Cards de fim de cadeia continuam usando o nível calculado pelo backend.
-    // Os demais nós usam node.depth (profundidade calculada pelo d3.hierarchy
-    // a partir da estrutura de árvore que converterParaArvoreD3 já monta
-    // corretamente) -- usar node.data.nivel aqui prenderia a posição X ao
-    // nível antigo do backend, ignorando o pai primário escolhido acima.
+    // Um documento com nível ajustado manualmente (nivel_manual, endpoint
+    // ajustar-nivel) também respeita a escolha do usuário. Os demais nós
+    // usam node.depth (profundidade calculada pelo d3.hierarchy a partir da
+    // estrutura de árvore que converterParaArvoreD3 já monta corretamente)
+    // -- usar node.data.nivel para todo mundo prenderia a posição X ao nível
+    // antigo do backend, ignorando o pai primário escolhido acima.
     root.descendants().forEach(node => {
         if (node.data.is_fim_cadeia) {
             const nivel = node.data.nivel || 0;
             node.y = nivel * 200 + 120;
             console.log(`DEBUG POSIÇÃO FIM CADEIA: ${node.data.numero} - nível backend: ${nivel}, posição Y: ${node.y}`);
+            return;
+        }
+
+        if (node.data.nivel_manual != null) {
+            const nivel = node.data.nivel ?? node.depth;
+            node.y = nivel * 200 + 120;
             return;
         }
 

--- a/static/dominial/js/cadeia_dominial_d3.js
+++ b/static/dominial/js/cadeia_dominial_d3.js
@@ -167,9 +167,13 @@ document.addEventListener('DOMContentLoaded', function() {
 function ordenarFilhosPorNumeroDesc(nodo) {
     if (nodo.children && nodo.children.length > 0) {
         nodo.children.sort((a, b) => {
-            // Extrair número ignorando prefixos não numéricos
-            const numA = parseInt((a.numero || '').replace(/\D/g, ''));
-            const numB = parseInt((b.numero || '').replace(/\D/g, ''));
+            // Matrículas sempre antes de transcrições; dentro do mesmo tipo, maior número primeiro
+            const tipoA = a.tipo_documento === 'matricula' ? 0 : 1;
+            const tipoB = b.tipo_documento === 'matricula' ? 0 : 1;
+            if (tipoA !== tipoB) return tipoA - tipoB;
+
+            const numA = parseInt((a.numero || '').replace(/\D/g, ''), 10) || 0;
+            const numB = parseInt((b.numero || '').replace(/\D/g, ''), 10) || 0;
             return numB - numA;
         });
         nodo.children.forEach(ordenarFilhosPorNumeroDesc);
@@ -178,144 +182,85 @@ function ordenarFilhosPorNumeroDesc(nodo) {
 
 function converterParaArvoreD3(data) {
     console.log(`DEBUG: Iniciando conversão - Backend enviou ${data.documentos.length} documentos únicos`);
-    
+
     // Mapear documentos por número
     const docMap = {};
     data.documentos.forEach(doc => {
         doc.children = [];
         docMap[doc.numero] = doc;
     });
-    
+
     // Encontrar a matrícula principal (raiz)
     let raiz = data.documentos.find(doc => doc.nivel === 0 || doc.origem === '' || doc.origem == null);
     if (!raiz) raiz = data.documentos[0];
-    
+
     console.log(`DEBUG: Raiz identificada: ${raiz.numero}`);
-    
-    // CORREÇÃO: Abordagem simples - usar apenas as conexões do backend
-    // Construir árvore diretamente das conexões, garantindo que cada documento apareça apenas uma vez
-    
-    const visitados = new Set();
-    const documentosNaArvore = new Set();
-    
-    // Função para construir árvore sem duplicação
-    function construirArvoreSimples(node) {
-        if (!node || visitados.has(node.numero)) {
-            console.log(`DEBUG: Pulando nó ${node?.numero} - já visitado ou nulo`);
-            return;
+
+    // CORREÇÃO: um documento pode ser citado como origem por mais de um
+    // documento (grafo, não árvore). Quando isso acontece, o documento deve
+    // pertencer ao citante MAIS PROFUNDO (mais distante da raiz) -- senão a
+    // citação do citante mais raso vira uma linha secundária cruzando
+    // verticalmente irmãos da mesma coluna. Calculamos o caminho mais longo
+    // a partir da raiz (relaxamento iterativo, não BFS de caminho mais
+    // curto) e usamos o citante que produz esse caminho como pai primário;
+    // qualquer outra citação vira conexão secundária (linha tracejada), que
+    // assim sempre "avança" para uma coluna mais profunda, nunca cruza a
+    // mesma coluna.
+    const conexoesPorFrom = new Map();
+    data.conexoes.forEach(con => {
+        if (!conexoesPorFrom.has(con.from)) conexoesPorFrom.set(con.from, []);
+        conexoesPorFrom.get(con.from).push(con);
+    });
+
+    const profundidade = new Map([[raiz.numero, 0]]);
+    const paiPrimario = new Map();
+    const fila = [raiz.numero];
+    let iteracoes = 0;
+    const limiteIteracoes = data.documentos.length * data.conexoes.length + data.documentos.length;
+
+    while (fila.length > 0) {
+        if (++iteracoes > limiteIteracoes) {
+            console.warn('DEBUG: possível ciclo nas conexões, interrompendo cálculo de profundidade');
+            break;
         }
-        
-        console.log(`DEBUG: Processando nó ${node.numero}`);
-        visitados.add(node.numero);
-        documentosNaArvore.add(node.numero);
-        
-        // Buscar filhos deste nó nas conexões (from = filho, to = pai)
-        const filhos = data.conexoes
-            .filter(con => con.from === node.numero)
-            .map(con => docMap[con.to])
-            .filter(doc => doc);
-        
-        console.log(`DEBUG: Nó ${node.numero} tem ${filhos.length} filhos: ${filhos.map(f => f.numero).join(', ')}`);
-        
-        // Adicionar filhos únicos (referências aos mesmos objetos)
-        filhos.forEach(filho => {
-            if (!node.children.some(child => child.numero === filho.numero)) {
-                // CORREÇÃO: Só adicionar se o filho ainda não foi visitado
-                if (!visitados.has(filho.numero)) {
-                    console.log(`DEBUG: Adicionando filho ${filho.numero} ao nó ${node.numero}`);
-                    node.children.push(filho);
-                    documentosNaArvore.add(filho.numero);
-                } else {
-                    console.log(`DEBUG: Filho ${filho.numero} já foi visitado, não adicionando ao nó ${node.numero}`);
-                }
-            } else {
-                console.log(`DEBUG: Filho ${filho.numero} já existe no nó ${node.numero}`);
+        const atual = fila.shift();
+        (conexoesPorFrom.get(atual) || []).forEach(con => {
+            if (!docMap[con.to]) return;
+            const novaProfundidade = profundidade.get(atual) + 1;
+            if (!profundidade.has(con.to) || novaProfundidade > profundidade.get(con.to)) {
+                profundidade.set(con.to, novaProfundidade);
+                paiPrimario.set(con.to, atual);
+                fila.push(con.to);
             }
         });
-        
-        // Processar filhos recursivamente APENAS se não foram visitados
-        if (node.children) {
-            node.children.forEach(filho => {
-                if (!visitados.has(filho.numero)) {
-                    console.log(`DEBUG: Processando recursivamente filho ${filho.numero} de ${node.numero}`);
-                    construirArvoreSimples(filho);
-                } else {
-                    console.log(`DEBUG: Filho ${filho.numero} já foi visitado, pulando recursão`);
-                }
-            });
-        }
     }
-    
-    // Função para verificar se uma conexão já existe na árvore
-    function verificarConexaoExiste(node, from, to) {
-        if (!node) return false;
-        
-        // Verificar se este nó tem a conexão direta
-        if (node.numero === from && node.children) {
-            return node.children.some(child => child.numero === to);
-        }
-        
-        // Verificar recursivamente nos filhos
-        if (node.children) {
-            return node.children.some(child => verificarConexaoExiste(child, from, to));
-        }
-        
-        return false;
-    }
-    
-    // Construir árvore simples
-    construirArvoreSimples(raiz);
-    
-    // Verificar se há documentos não visitados
-    const documentosNaoVisitados = data.documentos.filter(doc => !visitados.has(doc.numero));
-    console.log(`DEBUG: Documentos não visitados: ${documentosNaoVisitados.length}`);
-    console.log(`DEBUG: Documentos na árvore: ${documentosNaArvore.size}`);
-    
-    // ETAPA 3: Criar conexões secundárias (traços sem duplicar cards)
+
     const conexoesSecundarias = [];
-    
-    // Identificar conexões que foram perdidas devido à lógica de visitados
-    data.conexoes.forEach(conexao => {
-        const pai = docMap[conexao.to];
-        const filho = docMap[conexao.from];
-        
-        if (pai && filho) {
-            // Verificar se esta conexão não está representada na árvore principal
-            const conexaoExiste = verificarConexaoExiste(raiz, conexao.from, conexao.to);
-            
-            if (!conexaoExiste) {
-                console.log(`DEBUG: Criando conexão secundária: ${conexao.from} -> ${conexao.to}`);
-                conexoesSecundarias.push({
-                    from: conexao.from,
-                    to: conexao.to,
-                    tipo: 'conexao_secundaria'
-                });
-            }
+    data.conexoes.forEach(con => {
+        if (!docMap[con.to] || !docMap[con.from]) return;
+        if (!profundidade.has(con.to)) return;
+
+        if (paiPrimario.get(con.to) === con.from) {
+            docMap[con.from].children.push(docMap[con.to]);
+        } else {
+            // Documento já pertence a outro nó da árvore: conecta sem duplicar o card
+            console.log(`DEBUG: Conexão secundária: ${con.from} -> ${con.to}`);
+            conexoesSecundarias.push({
+                from: con.from,
+                to: con.to,
+                tipo: 'conexao_secundaria'
+            });
         }
     });
-    
-    console.log(`DEBUG: Total de conexões secundárias criadas: ${conexoesSecundarias.length}`);
-    
+
+    console.log(`DEBUG: Documentos na árvore: ${profundidade.size}, conexões secundárias: ${conexoesSecundarias.length}`);
+
     // Adicionar conexões secundárias à raiz
     raiz.conexoesExtras = conexoesSecundarias;
-    
+
     // Ordenar filhos recursivamente
     ordenarFilhosPorNumeroDesc(raiz);
-    
-    // DEBUG: Contar total de nós na árvore final
-    function contarNos(node) {
-        let total = 1;
-        if (node.children) {
-            node.children.forEach(child => {
-                total += contarNos(child);
-            });
-        }
-        return total;
-    }
-    
-    const totalNos = contarNos(raiz);
-    console.log(`DEBUG: Total de nós na árvore final: ${totalNos}`);
-    
+
     return raiz;
 }
 
@@ -476,20 +421,20 @@ function corrigirSobreposicoes(root) {
 
 // Função otimizada: Aplicar espaçamento adicional para evitar sobreposições
 function ajustarPosicoesPorNivel(root) {
-    // Ajustar posições horizontais baseado no campo 'nivel' dos dados
+    // Cards de fim de cadeia continuam usando o nível calculado pelo backend.
+    // Os demais nós usam node.depth (profundidade calculada pelo d3.hierarchy
+    // a partir da estrutura de árvore que converterParaArvoreD3 já monta
+    // corretamente) -- usar node.data.nivel aqui prenderia a posição X ao
+    // nível antigo do backend, ignorando o pai primário escolhido acima.
     root.descendants().forEach(node => {
-        const nivel = node.data.nivel || 0;
-        
-        // Cards de fim de cadeia usam o nível do backend para posicionamento
         if (node.data.is_fim_cadeia) {
-            // Usar o nível do backend para posicionar corretamente
+            const nivel = node.data.nivel || 0;
             node.y = nivel * 200 + 120;
             console.log(`DEBUG POSIÇÃO FIM CADEIA: ${node.data.numero} - nível backend: ${nivel}, posição Y: ${node.y}`);
             return;
         }
-        
-        // Posicionar horizontalmente baseado no nível (200px por nível)
-        node.y = nivel * 200 + 120;
+
+        node.y = node.depth * 200 + 120;
     });
 }
 


### PR DESCRIPTION
## Resumo

O gráfico D3 da cadeia dominial voltou a exibir problemas já resolvidos antes: documentos duplicados como dois cards separados e, ao corrigir isso, uma linha secundária (tracejada) cruzando verticalmente o organograma. Causa raiz confirmada contra dados reais (imóvel M18372, id=59): `M15396` cita `M12824/M15022/M14974/M1601`, e `M15022` (já filho de `M15396`) também cita `M1601/M14974` — um DAG legítimo, não duplicata de dado.

- `converterParaArvoreD3` (`static/dominial/js/cadeia_dominial_d3.js`): a escolha de "pai primário" para um documento citado por mais de um citante era feita por busca em largura (o citante mais raso vencia). Isso abria uma janela de corrida em `construirArvoreSimples` que duplicava o mesmo objeto em dois arrays `children` (causa dos cards duplicados) e, mesmo depois de fechar essa janela, deixava o documento na mesma coluna do seu segundo citante — forçando a linha secundária a cruzar verticalmente os irmãos daquela coluna. Trocado por um cálculo de caminho mais longo a partir da raiz (relaxamento iterativo): o citante mais profundo vence, empurrando o documento para uma coluna compatível e fazendo a linha secundária sempre avançar em diagonal.
- `ordenarFilhosPorNumeroDesc`: passa a priorizar tipo (matrícula antes de transcrição) e só então o número, evitando misturar os dois por comparação numérica crua do número sem prefixo.
- `ajustarPosicoesPorNivel`: nós normais passam a usar `node.depth` (profundidade real da árvore que acabamos de construir) em vez de `node.data.nivel` (nível calculado pelo backend, com a mesma semântica de caminho mais curto) — sem isso o card ficava preso na coluna antiga mesmo com a árvore lógica corrigida. Cards de fim de cadeia continuam usando o nível do backend, sem mudança.

Sem alterações de backend nem migrations — mudança isolada a um único arquivo estático.

## Test plan

- [x] Harness Node standalone rodando as funções reais do arquivo contra o JSON extraído do banco para o caso real do bug (imóvel M18372) — confirma dedupe, colunas e conexões secundárias esperadas.
- [x] Regressão: cadeia simples sem convergência (sem DAG) renderiza igual a antes.
- [x] Ordenação: mistura sintética de matrícula/transcrição confirma matrículas sempre antes.
- [x] `node --check` no arquivo (sintaxe válida).
- [x] Testado visualmente em servidor local (worktree isolada + cópia migrada do dump real) pelo usuário, confirmando que os documentos não duplicam mais e a linha secundária não cruza mais verticalmente o organograma.
- [ ] Revisão/teste em ambiente de teste com o banco completo (404 imóveis) para checar casos mais complexos de convergência.

🤖 Generated with [Claude Code](https://claude.com/claude-code)