### PR TITLE
fix(deploy): collectstatic sempre executa no start

### DIFF
--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -120,16 +120,14 @@ run_migrations() {
 
 # Função para coletar arquivos estáticos
 collect_static() {
-    echo "📦 Verificando arquivos estáticos..."
-    # Os arquivos estáticos já foram coletados durante o build
-    # Apenas verifica se o diretório existe
-    if [ -d "/app/staticfiles" ]; then
-        echo "✅ Arquivos estáticos já coletados durante o build."
-    else
-        echo "⚠️ Diretório staticfiles não encontrado, coletando..."
-        python manage.py collectstatic --noinput
-        echo "✅ Arquivos estáticos coletados!"
-    fi
+    # Sempre roda: collectstatic é idempotente (só copia o que mudou) e
+    # rápido. Rodar condicionalmente à existência do diretório fazia com que
+    # JS/CSS alterados em commits posteriores ao primeiro build nunca fossem
+    # recopiados para /app/staticfiles em restarts subsequentes, deixando o
+    # nginx servir versões desatualizadas indefinidamente.
+    echo "📦 Coletando arquivos estáticos..."
+    python manage.py collectstatic --noinput
+    echo "✅ Arquivos estáticos coletados!"
 }
 
 # Função principal


### PR DESCRIPTION
## Summary
- `scripts/init.sh` só rodava `collectstatic` quando `/app/staticfiles` não existia. Como esse diretório persiste entre builds/restarts, JS/CSS alterados em commits posteriores ao primeiro build nunca eram recopiados, deixando o nginx servir arquivos estáticos desatualizados indefinidamente.
- Caso real encontrado em produção: o fix de duplicação de cards na árvore D3 (`b3a5cf3`) já estava mergeado no `main` há dias, mas o JS servido continuava sendo uma versão anterior — só foi corrigido rodando `collectstatic` manualmente.
- `collectstatic --noinput` é idempotente e rápido (só copia o que mudou), então passa a rodar sempre, sem condicional.

## Test plan
- [x] `bash -n scripts/init.sh` (sintaxe válida)
- [x] Rodado manualmente em produção (`docker exec cadeia_dominial_web python manage.py collectstatic --noinput`): copiou os arquivos desatualizados corretamente, hash bateu com a fonte
- [ ] Confirmar em um próximo `docker-compose up` que o script continua subindo o Gunicorn normalmente

🤖 Generated with [Claude Code](https://claude.com/claude-code)